### PR TITLE
fix: uniformize icon sizes in input bar

### DIFF
--- a/desktop/css/alfred.css
+++ b/desktop/css/alfred.css
@@ -280,8 +280,8 @@
 }
 
 #alfred-send {
-    width: 38px;
-    height: 38px;
+    width: 34px;
+    height: 34px;
     border-radius: 50%;
     background: #337ab7;
     color: #fff;
@@ -304,8 +304,8 @@
 }
 
 #alfred-mic {
-    width: 38px;
-    height: 38px;
+    width: 34px;
+    height: 34px;
     border-radius: 50%;
     background: #6c757d;
     color: #fff;
@@ -342,8 +342,8 @@
 
 #alfred-tts,
 #alfred-mic-autosend {
-    width: 30px;
-    height: 30px;
+    width: 34px;
+    height: 34px;
     border-radius: 50%;
     background: transparent;
     color: #aaa;
@@ -353,14 +353,14 @@
     align-items: center;
     justify-content: center;
     flex-shrink: 0;
-    font-size: 12px;
+    font-size: 13px;
     padding: 0;
     transition: all 0.15s;
 }
 
 #alfred-tts-settings {
-    width: 22px;
-    height: 22px;
+    width: 34px;
+    height: 34px;
     border-radius: 50%;
     background: transparent;
     color: #ccc;
@@ -370,7 +370,7 @@
     align-items: center;
     justify-content: center;
     flex-shrink: 0;
-    font-size: 10px;
+    font-size: 13px;
     padding: 0;
     transition: all 0.15s;
 }


### PR DESCRIPTION
Resolves #9

## Summary
- All buttons to the right of the text input now share the same **34×34 px** size
- Previously: `#alfred-send` and `#alfred-mic` were 38 px, `#alfred-tts` and `#alfred-mic-autosend` were 30 px, `#alfred-tts-settings` was only 22 px
- Also bumped icon font-size from 12 px / 10 px to 13 px for the smaller buttons for better legibility at the new size

## Changes
- `desktop/css/alfred.css` — set consistent 34×34 px on all five input-bar buttons