### PR TITLE
feat: TTS playback controls (play/pause/resume/stop) per message

### DIFF
--- a/desktop/css/alfred.css
+++ b/desktop/css/alfred.css
@@ -199,6 +199,49 @@
     border-bottom-left-radius: 2px;
 }
 
+/* Per-message TTS action bar */
+.alfred-msg.assistant {
+    flex-direction: column;
+}
+
+.alfred-msg-actions {
+    display: flex;
+    gap: 4px;
+    padding-left: 2px;
+    opacity: 0;
+    transition: opacity 0.15s;
+}
+
+.alfred-msg.assistant:hover .alfred-msg-actions {
+    opacity: 1;
+}
+
+.alfred-tts-btn {
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    background: transparent;
+    color: #aaa;
+    border: 1px solid #ddd;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 9px;
+    padding: 0;
+    line-height: 1;
+    transition: all 0.15s;
+}
+
+.alfred-tts-btn:hover {
+    border-color: #337ab7;
+    color: #337ab7;
+}
+
+.alfred-tts-btn.hidden {
+    display: none;
+}
+
 /* Tool call indicator */
 .alfred-tool-call {
     align-self: flex-start;

--- a/desktop/js/alfred.js
+++ b/desktop/js/alfred.js
@@ -21,9 +21,11 @@ $(function () {
     var micCommitted    = ''; // accumulated final transcripts
 
     // Text-to-speech state
-    var ttsEnabled = localStorage.getItem('alfred_tts') === '1';
-    var ttsVoice   = null; // SpeechSynthesisVoice object
-    var ttsRate    = parseFloat(localStorage.getItem('alfred_tts_rate') || '1');
+    var ttsEnabled    = localStorage.getItem('alfred_tts') === '1';
+    var ttsVoice      = null; // SpeechSynthesisVoice object
+    var ttsRate       = parseFloat(localStorage.getItem('alfred_tts_rate') || '1');
+    var ttsCurrentMsg = null; // $msg element currently playing/paused
+    var ttsCurrentUtt = null; // current SpeechSynthesisUtterance
 
     // =========================================================================
     // Sidebar toggle (mobile)
@@ -143,6 +145,11 @@ $(function () {
     $('#alfred-send').on('click', function () {
         if (isStreaming) return;
         if (isListening) { recognition.stop(); }
+        if (ttsCurrentMsg) {
+            setMsgTtsState(ttsCurrentMsg, 'idle');
+            ttsCurrentMsg = null;
+            ttsCurrentUtt = null;
+        }
         speechSynthesis.cancel();
         var text = $('#alfred-input').val().trim();
         if (!text) return;
@@ -168,7 +175,14 @@ $(function () {
             ttsEnabled = !ttsEnabled;
             localStorage.setItem('alfred_tts', ttsEnabled ? '1' : '0');
             $btn.toggleClass('active', ttsEnabled);
-            if (!ttsEnabled) speechSynthesis.cancel();
+            if (!ttsEnabled) {
+                if (ttsCurrentMsg) {
+                    setMsgTtsState(ttsCurrentMsg, 'idle');
+                    ttsCurrentMsg = null;
+                    ttsCurrentUtt = null;
+                }
+                speechSynthesis.cancel();
+            }
         });
 
         // Build settings popover
@@ -248,10 +262,8 @@ $(function () {
         });
     }());
 
-    function speak(text) {
-        if (!ttsEnabled || !window.speechSynthesis || !text) return;
-        speechSynthesis.cancel();
-        var clean = text
+    function cleanTtsText(text) {
+        return text
             .replace(/```[\s\S]*?```/g, '')
             .replace(/`[^`]*`/g, '')
             .replace(/\*\*([^*]+)\*\*/g, '$1')
@@ -261,8 +273,10 @@ $(function () {
             .replace(/[_~>|]/g, '')
             .replace(/\n+/g, ' ')
             .trim();
-        if (!clean) return;
-        var utt = new SpeechSynthesisUtterance(clean);
+    }
+
+    function buildMsgUtterance(text, $msgEl) {
+        var utt = new SpeechSynthesisUtterance(text);
         if (ttsVoice) {
             utt.voice = ttsVoice;
             utt.lang  = ttsVoice.lang;
@@ -270,7 +284,77 @@ $(function () {
             utt.lang = navigator.language || 'fr-FR';
         }
         utt.rate = (ttsRate > 0) ? ttsRate : 1;
+        utt.onend = function () {
+            if (ttsCurrentMsg && ttsCurrentMsg[0] === $msgEl[0]) {
+                setMsgTtsState($msgEl, 'idle');
+                ttsCurrentMsg = null;
+                ttsCurrentUtt = null;
+            }
+        };
+        return utt;
+    }
+
+    function setMsgTtsState($msg, state) {
+        $msg.find('.alfred-tts-play').toggleClass('hidden', state !== 'idle');
+        $msg.find('.alfred-tts-pause').toggleClass('hidden', state !== 'playing');
+        $msg.find('.alfred-tts-resume').toggleClass('hidden', state !== 'paused');
+        $msg.find('.alfred-tts-stop').toggleClass('hidden', state !== 'paused');
+    }
+
+    function speakMsg($msg) {
+        if (!window.speechSynthesis) return;
+        if (ttsCurrentMsg && ttsCurrentMsg[0] !== $msg[0]) {
+            setMsgTtsState(ttsCurrentMsg, 'idle');
+        }
+        speechSynthesis.cancel();
+        var text = $msg.data('tts-text');
+        if (!text) return;
+        var clean = cleanTtsText(text);
+        if (!clean) return;
+        var utt = buildMsgUtterance(clean, $msg);
+        ttsCurrentMsg = $msg;
+        ttsCurrentUtt = utt;
+        setMsgTtsState($msg, 'playing');
         speechSynthesis.speak(utt);
+    }
+
+    function pauseMsg($msg) {
+        if (!ttsCurrentMsg || ttsCurrentMsg[0] !== $msg[0]) return;
+        speechSynthesis.pause();
+        setMsgTtsState($msg, 'paused');
+    }
+
+    function resumeMsg($msg) {
+        if (!ttsCurrentMsg || ttsCurrentMsg[0] !== $msg[0]) return;
+        speechSynthesis.resume();
+        setMsgTtsState($msg, 'playing');
+    }
+
+    function stopMsg($msg) {
+        if (!ttsCurrentMsg || ttsCurrentMsg[0] !== $msg[0]) return;
+        speechSynthesis.cancel();
+        setMsgTtsState($msg, 'idle');
+        ttsCurrentMsg = null;
+        ttsCurrentUtt = null;
+    }
+
+    function speak(text, $msgEl) {
+        if (!ttsEnabled || !window.speechSynthesis || !text) return;
+        if (ttsCurrentMsg) {
+            setMsgTtsState(ttsCurrentMsg, 'idle');
+        }
+        speechSynthesis.cancel();
+        var clean = cleanTtsText(text);
+        if (!clean) return;
+        if ($msgEl) {
+            var utt = buildMsgUtterance(clean, $msgEl);
+            ttsCurrentMsg = $msgEl;
+            ttsCurrentUtt = utt;
+            setMsgTtsState($msgEl, 'playing');
+            speechSynthesis.speak(utt);
+        } else {
+            speechSynthesis.speak(new SpeechSynthesisUtterance(clean));
+        }
     }
 
     // =========================================================================
@@ -440,13 +524,17 @@ $(function () {
         source.addEventListener('done', function (e) {
             var d = JSON.parse(e.data);
             hideTyping();
-            if (!$assistantBubble && d.text) {
-                appendBubble('assistant', d.text);
+            var finalText = d.text || assistantText;
+            if (!$assistantBubble && finalText) {
+                $assistantBubble = appendBubble('assistant', finalText);
+            }
+            if ($assistantBubble) {
+                $assistantBubble.data('tts-text', finalText);
             }
             if (d.limit_reached) {
                 appendLimitReached(sessionId);
             } else {
-                speak(d.text || assistantText);
+                speak(finalText, $assistantBubble);
             }
             source.close();
             currentSource = null;
@@ -513,6 +601,20 @@ $(function () {
     function appendBubble(role, text) {
         var $bubble = $('<div class="alfred-msg-bubble">').html(markdownToHtml(text));
         var $msg    = $('<div class="alfred-msg ' + role + '">').append($bubble);
+        if (role === 'assistant' && window.speechSynthesis) {
+            $msg.data('tts-text', text);
+            var $actions = $('<div class="alfred-msg-actions">');
+            var $btnPlay   = $('<button class="alfred-tts-btn alfred-tts-play"          title="{{Play}}"><i class="fas fa-play"></i></button>');
+            var $btnPause  = $('<button class="alfred-tts-btn alfred-tts-pause  hidden" title="{{Pause}}"><i class="fas fa-pause"></i></button>');
+            var $btnResume = $('<button class="alfred-tts-btn alfred-tts-resume hidden" title="{{Resume}}"><i class="fas fa-play"></i></button>');
+            var $btnStop   = $('<button class="alfred-tts-btn alfred-tts-stop   hidden" title="{{Stop}}"><i class="fas fa-stop"></i></button>');
+            $btnPlay.on('click',   function () { speakMsg($msg); });
+            $btnPause.on('click',  function () { pauseMsg($msg); });
+            $btnResume.on('click', function () { resumeMsg($msg); });
+            $btnStop.on('click',   function () { stopMsg($msg); });
+            $actions.append($btnPlay, $btnPause, $btnResume, $btnStop);
+            $msg.append($actions);
+        }
         $('#alfred-messages').append($msg);
         scrollToBottom();
         return $msg;


### PR DESCRIPTION
## Summary

- Adds ▶ Play, ⏸ Pause, ▶ Resume, and ⏹ Stop buttons to every assistant message bubble
- Buttons are shown/hidden based on playback state (idle / playing / paused)
- Uses `speechSynthesis.pause()` / `resume()` to preserve position mid-sentence
- Only one message plays at a time — starting a new one stops the current
- Auto-play after response completion also drives the per-message button state
- Action bar fades in on hover for a clean UI

Resolves #12

## Test plan
- [ ] Every assistant message shows ▶ Play when idle
- [ ] Clicking ▶ starts TTS and switches to ⏸ Pause
- [ ] Clicking ⏸ pauses mid-sentence, shows ▶ Resume + ⏹ Stop
- [ ] Clicking ▶ Resume continues from pause position
- [ ] Clicking ⏹ Stop returns to ▶ Play (idle)
- [ ] Audio ending naturally returns to ▶ Play (idle)
- [ ] Starting playback on a second message stops the first
- [ ] Global TTS toggle disabling resets any active per-message state
- [ ] Sending a message resets any active per-message state

🤖 Generated with [Claude Code](https://claude.com/claude-code)