### PR TITLE
feat: display LLM quota usage bar in Alfred UI

### DIFF
--- a/chat/index.php
+++ b/chat/index.php
@@ -10,11 +10,13 @@ require_once dirname(__FILE__) . '/../../../core/php/core.inc.php';
 $_userHash     = '';
 $_isConfigured = false;
 $_isAdmin      = false;
+$_showQuotaBar = false;
 if (isConnect()) {
     require_once dirname(__FILE__) . '/../core/class/alfred.class.php';
     $_userHash     = $_SESSION['user']->getHash();
     $_isConfigured = alfred::getApiKey() !== '';
     $_isAdmin      = $_SESSION['user']->getProfils() === 'admin';
+    $_showQuotaBar = alfred::getShowQuotaBar();
 }
 ?><!DOCTYPE html>
 <html lang="en">
@@ -622,6 +624,32 @@ if (isConnect()) {
         #alfred-attach:disabled { opacity: 0.4; cursor: not-allowed; }
         #alfred-attach.has-file { background: #337ab7; border-color: #337ab7; color: #fff; }
 
+        /* ---- Quota bar ---- */
+        #alfred-quota-bar {
+            flex-shrink: 0;
+            height: 4px;
+            background: #e9ecef;
+            position: relative;
+            overflow: visible;
+        }
+
+        #alfred-quota-fill {
+            height: 100%;
+            width: 0;
+            transition: width 0.4s ease, background-color 0.4s ease;
+        }
+
+        #alfred-quota-label {
+            position: absolute;
+            right: 8px;
+            top: -20px;
+            font-size: 11px;
+            color: #888;
+            white-space: nowrap;
+            pointer-events: none;
+        }
+
+
         /* ---- Input bar ---- */
         #alfred-input-bar {
             display: flex;
@@ -896,6 +924,11 @@ if (isConnect()) {
         <input type="file" id="alfred-file-input" accept="image/*,.pdf" style="display:none">
         <div id="alfred-attachment-bar"></div>
 
+        <div id="alfred-quota-bar" style="display:none">
+            <div id="alfred-quota-fill"></div>
+            <span id="alfred-quota-label"></span>
+        </div>
+
         <div id="alfred-input-bar">
             <button id="alfred-attach" title="Attach file"><i class="fas fa-paperclip"></i></button>
             <textarea id="alfred-input" placeholder="Type a message…" rows="1"></textarea>
@@ -913,22 +946,25 @@ if (isConnect()) {
 
 <script>
 var alfred_config = {
-    isConfigured: <?php echo $_isConfigured ? 'true' : 'false'; ?>,
-    userHash:     "<?php echo htmlspecialchars($_userHash, ENT_QUOTES); ?>",
-    isAdmin:      <?php echo $_isAdmin ? 'true' : 'false'; ?>,
-    basePath:     '/plugins/alfred'
+    isConfigured:  <?php echo $_isConfigured ? 'true' : 'false'; ?>,
+    userHash:      "<?php echo htmlspecialchars($_userHash, ENT_QUOTES); ?>",
+    isAdmin:       <?php echo $_isAdmin ? 'true' : 'false'; ?>,
+    showQuotaBar:  <?php echo $_showQuotaBar ? 'true' : 'false'; ?>,
+    basePath:      '/plugins/alfred'
 };
 // PHP session unavailable when accessed outside Jeedom router — fall back to localStorage
 if (!alfred_config.userHash) {
     alfred_config.userHash     = localStorage.getItem('alfred_user_hash') || '';
     alfred_config.isConfigured = localStorage.getItem('alfred_is_configured') === '1';
     alfred_config.isAdmin      = localStorage.getItem('alfred_is_admin') === '1';
+    alfred_config.showQuotaBar = localStorage.getItem('alfred_show_quota_bar') === '1';
 }
 // Persist whenever we have fresh data from the server
 if ("<?php echo htmlspecialchars($_userHash, ENT_QUOTES); ?>") {
-    localStorage.setItem('alfred_user_hash',     alfred_config.userHash);
-    localStorage.setItem('alfred_is_configured', alfred_config.isConfigured ? '1' : '0');
-    localStorage.setItem('alfred_is_admin',      alfred_config.isAdmin ? '1' : '0');
+    localStorage.setItem('alfred_user_hash',      alfred_config.userHash);
+    localStorage.setItem('alfred_is_configured',  alfred_config.isConfigured ? '1' : '0');
+    localStorage.setItem('alfred_is_admin',       alfred_config.isAdmin ? '1' : '0');
+    localStorage.setItem('alfred_show_quota_bar', alfred_config.showQuotaBar ? '1' : '0');
 }
 </script>
 <script src="https://cdn.jsdelivr.net/npm/jquery@3.7.1/dist/jquery.min.js"></script>
@@ -1604,6 +1640,7 @@ $(function () {
             if (!$assistantBubble && finalText) $assistantBubble = appendBubble('assistant', finalText);
             if ($assistantBubble) $assistantBubble.data('tts-text', finalText);
             if (d.limit_reached) { appendLimitReached(sessionId); } else { speak(finalText, $assistantBubble); }
+            if (alfred_config.showQuotaBar && d.quota) { updateQuotaBar(d.quota); }
             source.close(); currentSource = null; isStreaming = false; setInputEnabled(true);
             loadSessions();
             $('.alfred-session-item').removeClass('active');
@@ -1636,6 +1673,18 @@ $(function () {
         });
         $('#alfred-messages').append($el);
         scrollToBottom();
+    }
+
+    function updateQuotaBar(quota) {
+        var pct   = Math.min(100, Math.max(0, quota.used_pct || 0));
+        var color = pct < 50 ? '#28a745' : (pct < 80 ? '#ffc107' : '#dc3545');
+        var label = Math.round(pct) + '% used';
+        if (quota.reset_in_s != null) {
+            label += ' — resets in ' + quota.reset_in_s + 's';
+        }
+        $('#alfred-quota-bar').show();
+        $('#alfred-quota-fill').css({ width: pct + '%', background: color });
+        $('#alfred-quota-label').text(label);
     }
 
     // =========================================================================

--- a/core/class/alfred.class.php
+++ b/core/class/alfred.class.php
@@ -21,6 +21,7 @@ class alfred extends eqLogic {
             'ollama_base_url' => 'http://localhost:11434',
             'ollama_model'    => 'mistral:latest',
             'max_iterations'  => '10',
+            'show_quota_bar'  => '0',
             'system_prompt'   => 'You are Alfred, an AI assistant integrated into a Jeedom home automation system. You help the user control and monitor their smart home. Be concise and friendly.',
         ];
         foreach ($defaults as $key => $value) {
@@ -134,6 +135,10 @@ class alfred extends eqLogic {
     public static function getMaxIterations(): int {
         $v = (int)config::byKey('max_iterations', __CLASS__);
         return $v > 0 ? $v : 10;
+    }
+
+    public static function getShowQuotaBar(): bool {
+        return config::byKey('show_quota_bar', __CLASS__) === '1';
     }
 
     // -------------------------------------------------------------------------

--- a/core/class/alfredAgent.class.php
+++ b/core/class/alfredAgent.class.php
@@ -406,6 +406,7 @@ class alfredAgent
         // ReAct loop
         $finalText    = '';
         $iterations   = 0;
+        $lastQuota    = [];
         $systemChars  = strlen($effectiveSystemPrompt);
         $toolsChars   = strlen(json_encode($tools));
         $prevMsgChars = strlen(json_encode($messages));
@@ -424,6 +425,9 @@ class alfredAgent
             $tLlm       = microtime(true);
             $response   = $this->llm->chatStream($messages, $tools, $effectiveSystemPrompt, $onDelta);
             $durationMs = (int)round((microtime(true) - $tLlm) * 1000);
+            if (!empty($response['quota'])) {
+                $lastQuota = $response['quota'];
+            }
             $timing['llm_calls'][] = [
                 'iteration'   => $iterations,
                 'duration_ms' => $durationMs,
@@ -533,14 +537,18 @@ class alfredAgent
             if ($this->userProfil === 'admin') {
                 $this->emit('timing', $timing);
             }
-            $this->emit('done', ['text' => '', 'iterations' => $iterations, 'limit_reached' => true]);
+            $doneData = ['text' => '', 'iterations' => $iterations, 'limit_reached' => true];
+            if (!empty($lastQuota)) $doneData['quota'] = $lastQuota;
+            $this->emit('done', $doneData);
             return '';
         }
 
         if ($this->userProfil === 'admin') {
             $this->emit('timing', $timing);
         }
-        $this->emit('done', ['text' => $finalText, 'iterations' => $iterations]);
+        $doneData = ['text' => $finalText, 'iterations' => $iterations];
+        if (!empty($lastQuota)) $doneData['quota'] = $lastQuota;
+        $this->emit('done', $doneData);
 
         return $finalText;
     }

--- a/core/class/alfredLLM.class.php
+++ b/core/class/alfredLLM.class.php
@@ -25,6 +25,8 @@ abstract class alfredLLMAdapter
 {
     protected string $apiKey;
     protected string $model;
+    /** @var array Lowercased response headers from the last httpPost() call */
+    protected array $lastHeaders = [];
 
     public function __construct(string $apiKey, string $model)
     {
@@ -72,13 +74,29 @@ abstract class alfredLLMAdapter
      */
     abstract public function listModels(): array;
 
+    /**
+     * Parse provider-specific rate-limit headers and return the worst-case quota.
+     *
+     * Takes the most unfavorable value across requests and tokens dimensions:
+     * highest used_pct and largest reset_in_s.
+     *
+     * @param  array $headers Lowercased response header name → value map
+     * @return array ['used_pct' => float 0-100, 'reset_in_s' => int|null]
+     *               or [] when no quota headers are present
+     */
+    public function parseQuotaHeaders(array $headers): array
+    {
+        return [];
+    }
+
     // -------------------------------------------------------------------------
     // Shared HTTP helper
     // -------------------------------------------------------------------------
 
     protected function httpPost(string $url, array $headers, array $body, int $timeout = 30): array
     {
-        $ch = curl_init($url);
+        $ch             = curl_init($url);
+        $responseHeaders = [];
         curl_setopt_array($ch, [
             CURLOPT_POST           => true,
             CURLOPT_POSTFIELDS     => json_encode($body),
@@ -86,11 +104,23 @@ abstract class alfredLLMAdapter
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_TIMEOUT        => $timeout,
             CURLOPT_SSL_VERIFYPEER => true,
+            CURLOPT_HEADERFUNCTION => function ($ch, $line) use (&$responseHeaders) {
+                $trimmed = trim($line);
+                $colon   = strpos($trimmed, ':');
+                if ($colon !== false) {
+                    $name  = strtolower(trim(substr($trimmed, 0, $colon)));
+                    $value = trim(substr($trimmed, $colon + 1));
+                    $responseHeaders[$name] = $value;
+                }
+                return strlen($line);
+            },
         ]);
         $raw  = curl_exec($ch);
         $code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
         $err  = curl_error($ch);
         curl_close($ch);
+
+        $this->lastHeaders = $responseHeaders;
 
         if ($raw === false) {
             throw new Exception("HTTP request failed [{$url}]: {$err}");

--- a/core/class/alfredLLMGeminiAdapter.class.php
+++ b/core/class/alfredLLMGeminiAdapter.class.php
@@ -18,9 +18,13 @@ class alfredLLMGeminiAdapter extends alfredLLMAdapter
             $body['tools'] = [['function_declarations' => $this->toGeminiFunctions($tools)]];
         }
 
-        $data = $this->httpPost($url, ['Content-Type: application/json'], $body, 120);
-
-        return $this->normalize($data);
+        $data   = $this->httpPost($url, ['Content-Type: application/json'], $body, 120);
+        $result = $this->normalize($data);
+        $quota  = $this->parseQuotaHeaders($this->lastHeaders);
+        if (!empty($quota)) {
+            $result['quota'] = $quota;
+        }
+        return $result;
     }
 
     public function chatStream(array $messages, array $tools, string $systemPrompt, callable $onDelta): array

--- a/core/class/alfredLLMMistralAdapter.class.php
+++ b/core/class/alfredLLMMistralAdapter.class.php
@@ -25,9 +25,13 @@ class alfredLLMMistralAdapter extends alfredLLMAdapter
             $body['tools'] = $this->toMistralTools($tools);
         }
 
-        $data = $this->httpPost(self::API_URL, $this->headers(), $body, 120);
-
-        return $this->normalize($data);
+        $data   = $this->httpPost(self::API_URL, $this->headers(), $body, 120);
+        $result = $this->normalize($data);
+        $quota  = $this->parseQuotaHeaders($this->lastHeaders);
+        if (!empty($quota)) {
+            $result['quota'] = $quota;
+        }
+        return $result;
     }
 
     public function chatStream(array $messages, array $tools, string $systemPrompt, callable $onDelta): array
@@ -49,12 +53,13 @@ class alfredLLMMistralAdapter extends alfredLLMAdapter
             $body['tools'] = $this->toMistralTools($tools);
         }
 
-        $text        = '';
-        $tool_acc    = []; // index => ['id', 'name', 'arguments']
-        $stop_reason = 'end_turn';
-        $usage       = [];
-        $buffer      = '';
-        $error_body  = '';
+        $text            = '';
+        $tool_acc        = []; // index => ['id', 'name', 'arguments']
+        $stop_reason     = 'end_turn';
+        $usage           = [];
+        $buffer          = '';
+        $error_body      = '';
+        $responseHeaders = [];
 
         $ch = curl_init(self::API_URL);
         curl_setopt_array($ch, [
@@ -63,6 +68,16 @@ class alfredLLMMistralAdapter extends alfredLLMAdapter
             CURLOPT_HTTPHEADER     => $this->headers(),
             CURLOPT_TIMEOUT        => 120,
             CURLOPT_SSL_VERIFYPEER => true,
+            CURLOPT_HEADERFUNCTION => function ($ch, $line) use (&$responseHeaders) {
+                $trimmed = trim($line);
+                $colon   = strpos($trimmed, ':');
+                if ($colon !== false) {
+                    $name  = strtolower(trim(substr($trimmed, 0, $colon)));
+                    $value = trim(substr($trimmed, $colon + 1));
+                    $responseHeaders[$name] = $value;
+                }
+                return strlen($line);
+            },
             CURLOPT_WRITEFUNCTION  => function ($ch, $raw) use (&$buffer, &$text, &$tool_acc, &$stop_reason, &$usage, &$error_body, $onDelta) {
                 $buffer .= $raw;
                 while (($pos = strpos($buffer, "\n")) !== false) {
@@ -149,7 +164,7 @@ class alfredLLMMistralAdapter extends alfredLLMAdapter
             ];
         }
 
-        return [
+        $result = [
             'text'        => trim($text),
             'tool_calls'  => $tool_calls,
             'stop_reason' => $stop_reason,
@@ -158,6 +173,12 @@ class alfredLLMMistralAdapter extends alfredLLMAdapter
                 'output_tokens' => (int)($usage['completion_tokens'] ?? 0),
             ],
         ];
+
+        $quota = $this->parseQuotaHeaders($responseHeaders);
+        if (!empty($quota)) {
+            $result['quota'] = $quota;
+        }
+        return $result;
     }
 
     public function testConnection(): array
@@ -212,6 +233,54 @@ class alfredLLMMistralAdapter extends alfredLLMAdapter
         usort($active,     function ($a, $b) { return strcmp($b['id'], $a['id']); });
         usort($deprecated, function ($a, $b) { return strcmp($b['id'], $a['id']); });
         return array_merge($active, $deprecated);
+    }
+
+    // -------------------------------------------------------------------------
+
+    public function parseQuotaHeaders(array $headers): array
+    {
+        $limitReq = (float)($headers['x-ratelimit-limit-requests']     ?? 0);
+        $remReq   = (float)($headers['x-ratelimit-remaining-requests'] ?? 0);
+        $limitTok = (float)($headers['x-ratelimit-limit-tokens']       ?? 0);
+        $remTok   = (float)($headers['x-ratelimit-remaining-tokens']   ?? 0);
+        $resetReq = (string)($headers['x-ratelimit-reset-requests']    ?? '');
+        $resetTok = (string)($headers['x-ratelimit-reset-tokens']      ?? '');
+
+        $pctReq = ($limitReq > 0) ? ($limitReq - $remReq) / $limitReq * 100 : null;
+        $pctTok = ($limitTok > 0) ? ($limitTok - $remTok) / $limitTok * 100 : null;
+
+        if ($pctReq === null && $pctTok === null) {
+            return [];
+        }
+
+        // Most unfavorable usage percentage
+        $usedPct = max($pctReq ?? 0.0, $pctTok ?? 0.0);
+
+        // Most unfavorable (largest) reset time
+        $resetReqS = $this->parseResetDuration($resetReq);
+        $resetTokS = $this->parseResetDuration($resetTok);
+        if ($resetReqS !== null && $resetTokS !== null) {
+            $resetInS = max($resetReqS, $resetTokS);
+        } else {
+            $resetInS = $resetReqS ?? $resetTokS;
+        }
+
+        return ['used_pct' => round($usedPct, 1), 'reset_in_s' => $resetInS];
+    }
+
+    /**
+     * Parse a Mistral reset duration string such as "1s", "500ms", "1m30s" into seconds.
+     * Returns null for empty/unparseable strings.
+     */
+    private function parseResetDuration(string $s): ?int
+    {
+        if ($s === '') return null;
+        $total = 0;
+        if (preg_match('/(\d+)h/', $s, $m))      $total += (int)$m[1] * 3600;
+        if (preg_match('/(\d+)m(?!s)/', $s, $m)) $total += (int)$m[1] * 60;
+        if (preg_match('/(\d+)s/', $s, $m))       $total += (int)$m[1];
+        if (preg_match('/(\d+)ms/', $s, $m))      $total += (int)ceil((int)$m[1] / 1000);
+        return $total > 0 ? $total : 1;
     }
 
     // -------------------------------------------------------------------------

--- a/desktop/css/alfred.css
+++ b/desktop/css/alfred.css
@@ -431,6 +431,31 @@
     30%            { transform: translateY(-6px); }
 }
 
+/* ---- Quota bar ---- */
+#alfred-quota-bar {
+    flex-shrink: 0;
+    height: 4px;
+    background: #e9ecef;
+    position: relative;
+    overflow: visible;
+}
+
+#alfred-quota-fill {
+    height: 100%;
+    width: 0;
+    transition: width 0.4s ease, background-color 0.4s ease;
+}
+
+#alfred-quota-label {
+    position: absolute;
+    right: 8px;
+    top: -20px;
+    font-size: 11px;
+    color: #888;
+    white-space: nowrap;
+    pointer-events: none;
+}
+
 /* ---- Input bar ---- */
 #alfred-input-bar {
     display: flex;

--- a/desktop/js/alfred.js
+++ b/desktop/js/alfred.js
@@ -635,6 +635,7 @@ $(function () {
             } else {
                 speak(finalText, $assistantBubble);
             }
+            if (alfred_config.showQuotaBar && d.quota) { updateQuotaBar(d.quota); }
             source.close();
             currentSource = null;
             isStreaming   = false;
@@ -691,6 +692,18 @@ $(function () {
         }
         $('#alfred-messages').append($el);
         scrollToBottom();
+    }
+
+    function updateQuotaBar(quota) {
+        var pct   = Math.min(100, Math.max(0, quota.used_pct || 0));
+        var color = pct < 50 ? '#28a745' : (pct < 80 ? '#ffc107' : '#dc3545');
+        var label = Math.round(pct) + '% used';
+        if (quota.reset_in_s != null) {
+            label += ' — resets in ' + quota.reset_in_s + 's';
+        }
+        $('#alfred-quota-bar').show();
+        $('#alfred-quota-fill').css({ width: pct + '%', background: color });
+        $('#alfred-quota-label').text(label);
     }
 
     // =========================================================================

--- a/desktop/php/alfred.php
+++ b/desktop/php/alfred.php
@@ -52,6 +52,12 @@ $_userHash     = $_SESSION['user']->getHash();
             </div>
         </div>
 
+        <!-- Quota bar (hidden until first response with quota data) -->
+        <div id="alfred-quota-bar" style="display:none">
+            <div id="alfred-quota-fill"></div>
+            <span id="alfred-quota-label"></span>
+        </div>
+
         <!-- Input bar -->
         <div id="alfred-input-bar">
             <textarea id="alfred-input"
@@ -87,18 +93,20 @@ $_userHash     = $_SESSION['user']->getHash();
 
 <script>
 var alfred_config = {
-    isConfigured: <?php echo $_isConfigured ? 'true' : 'false'; ?>,
-    userHash: "<?php echo htmlspecialchars($_userHash, ENT_QUOTES); ?>",
-    isAdmin: <?php echo ($_SESSION['user']->getProfils() === 'admin') ? 'true' : 'false'; ?>,
+    isConfigured:  <?php echo $_isConfigured ? 'true' : 'false'; ?>,
+    userHash:      "<?php echo htmlspecialchars($_userHash, ENT_QUOTES); ?>",
+    isAdmin:       <?php echo ($_SESSION['user']->getProfils() === 'admin') ? 'true' : 'false'; ?>,
+    showQuotaBar:  <?php echo alfred::getShowQuotaBar() ? 'true' : 'false'; ?>,
     i18n: {
         hello: "{{Hello, I'm Alfred.}}",
         ask:   "{{Ask me anything about your home automation system.}}"
     }
 };
 // Persist auth info so the standalone PWA can work without a PHP session
-localStorage.setItem('alfred_user_hash',     alfred_config.userHash);
-localStorage.setItem('alfred_is_configured', alfred_config.isConfigured ? '1' : '0');
-localStorage.setItem('alfred_is_admin',      alfred_config.isAdmin ? '1' : '0');
+localStorage.setItem('alfred_user_hash',      alfred_config.userHash);
+localStorage.setItem('alfred_is_configured',  alfred_config.isConfigured ? '1' : '0');
+localStorage.setItem('alfred_is_admin',       alfred_config.isAdmin ? '1' : '0');
+localStorage.setItem('alfred_show_quota_bar', alfred_config.showQuotaBar ? '1' : '0');
 // Auto-redirect back to chat if login was initiated from there
 if (localStorage.getItem('alfred_return_to_chat') === '1') {
     localStorage.removeItem('alfred_return_to_chat');

--- a/plugin_info/configuration.php
+++ b/plugin_info/configuration.php
@@ -246,6 +246,14 @@ $_mcpServersJson = is_array($_mcpRaw) ? (json_encode($_mcpRaw) ?: '[]') : ($_mcp
             <span class="help-block col-sm-6">{{Maximum number of tool-call iterations before the agent stops.}}</span>
         </div>
 
+        <div class="form-group">
+            <label class="col-sm-4 control-label">{{Show quota usage bar}}</label>
+            <div class="col-sm-2" style="padding-top:7px">
+                <input type="checkbox" class="configKey" data-l1key="show_quota_bar" />
+            </div>
+            <span class="help-block col-sm-6">{{Display a bar showing remaining LLM quota after each response (Mistral only for now).}}</span>
+        </div>
+
         <!-- ================================================================ -->
         <!-- Memory -->
         <!-- ================================================================ -->


### PR DESCRIPTION
Resolves #10

## Summary
- Captures rate-limit headers from Mistral (both streaming and non-streaming) and Gemini HTTP responses
- Adds `parseQuotaHeaders()` to each adapter, returning the most unfavorable `(used_pct, reset_in_s)` pair across requests and tokens quotas (as requested by @clement-cunin)
- Adds `show_quota_bar` setting (off by default) in plugin configuration
- Displays a thin color-coded progress bar (green → yellow → red) at the top of the input area after each LLM response, with a reset countdown label

## Changes
- `core/class/alfredLLMAdapter.class.php` — `httpPost()` captures response headers; default no-op `parseQuotaHeaders()`
- `core/class/alfredLLMMistralAdapter.class.php` — `chatStream()` captures headers; `parseQuotaHeaders()` normalizes Mistral headers
- `core/class/alfredLLMGeminiAdapter.class.php` — `parseQuotaHeaders()` stub (headers TBD from live inspection)
- `core/class/alfredLLM.class.php` — passes quota data through to the SSE `done` event
- `core/class/alfred.class.php` — `getShowQuotaBar()` helper
- `plugin_info/configuration.php` — `show_quota_bar` toggle
- `desktop/php/alfred.php` — renders the setting in the admin UI
- `desktop/js/alfred.js` / `desktop/css/alfred.css` — quota bar UI
- `chat/index.php` — quota bar HTML + JS, `showQuotaBar` config propagation