### PR TITLE
fix: instruct LLM to quote tool errors verbatim instead of paraphrasing

### DIFF
--- a/core/class/alfredAgent.class.php
+++ b/core/class/alfredAgent.class.php
@@ -472,6 +472,12 @@ class alfredAgent
                  . "\n- Current user login: " . $this->userLogin
                  . "\n- Current user role: " . $role;
 
+        // Inject tool error reporting instructions
+        $prompt .= "\n\n## Tool error reporting"
+                 . "\nWhen a tool returns an error, always report the exact error message to the user verbatim,"
+                 . " formatted as: \"L'outil `<tool_name>` a retourné une erreur : `<exact_error_message>`\"."
+                 . " Do not paraphrase, interpret, or summarize tool errors — always quote them exactly.";
+
         $memories = alfredMemory::loadForUser($this->userLogin);
 
         // Inject memory block


### PR DESCRIPTION
## Summary

Resolves #28

When an MCP tool returns an error, Alfred was reformulating the error message in natural language rather than reporting the raw error text. This made it harder for users to diagnose failures.

- Adds a **"Tool error reporting"** section to the system prompt (injected in `buildSystemPrompt()`)
- Instructs the LLM to always quote tool error messages exactly, using the format: `L'outil \`<tool_name>\` a retourné une erreur : \`<exact_error_message>\``
- Applies to all tool types (MCP tools, synthetic tools)

## Test plan

- [ ] Trigger an MCP tool failure with invalid parameters (e.g. bad base64 for an upload)
- [ ] Verify Alfred now displays the exact error string from the tool result, not a paraphrase
- [ ] Verify normal (non-error) tool responses are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)