### PR TITLE
feat: add Ollama provider support

### DIFF
--- a/core/class/alfred.class.php
+++ b/core/class/alfred.class.php
@@ -16,8 +16,10 @@ class alfred extends eqLogic {
         }
         // Set default models
         $defaults = [
-            'mistral_model'  => 'mistral-large-latest',
-            'gemini_model'   => 'gemini-1.5-pro',
+            'mistral_model'   => 'mistral-large-latest',
+            'gemini_model'    => 'gemini-1.5-pro',
+            'ollama_base_url' => 'http://localhost:11434',
+            'ollama_model'    => 'mistral',
             'max_iterations'  => '10',
             'system_prompt'   => 'You are Alfred, an AI assistant integrated into a Jeedom home automation system. You help the user control and monitor their smart home. Be concise and friendly.',
         ];
@@ -95,6 +97,13 @@ class alfred extends eqLogic {
             $provider = self::getProvider();
         }
         return (string)config::byKey($provider . '_model', __CLASS__);
+    }
+
+    public static function getBaseUrl(string $provider = ''): string {
+        if ($provider === '') {
+            $provider = self::getProvider();
+        }
+        return (string)config::byKey($provider . '_base_url', __CLASS__);
     }
 
     public static function getMcpServers(): array {

--- a/core/class/alfred.class.php
+++ b/core/class/alfred.class.php
@@ -19,7 +19,7 @@ class alfred extends eqLogic {
             'mistral_model'   => 'mistral-large-latest',
             'gemini_model'    => 'gemini-1.5-pro',
             'ollama_base_url' => 'http://localhost:11434',
-            'ollama_model'    => 'mistral',
+            'ollama_model'    => 'mistral:latest',
             'max_iterations'  => '10',
             'system_prompt'   => 'You are Alfred, an AI assistant integrated into a Jeedom home automation system. You help the user control and monitor their smart home. Be concise and friendly.',
         ];

--- a/core/class/alfredAgent.class.php
+++ b/core/class/alfredAgent.class.php
@@ -145,6 +145,12 @@ class alfredAgent
             'filename'      => $filename,
         ];
         file_put_contents($dir . DIRECTORY_SEPARATOR . $fileId . '.json', json_encode($meta));
+
+        $eventsFile = $dir . DIRECTORY_SEPARATOR . '_events.json';
+        $pending    = file_exists($eventsFile) ? (json_decode(file_get_contents($eventsFile), true) ?: []) : [];
+        $pending[]  = ['file_id' => $fileId, 'filename' => $originalName, 'mime_type' => $mimeType, 'size' => strlen($content)];
+        file_put_contents($eventsFile, json_encode($pending), LOCK_EX);
+
         return $fileId;
     }
 
@@ -460,6 +466,7 @@ class alfredAgent
                     ? json_encode($result, JSON_UNESCAPED_UNICODE)
                     : (string)$result;
 
+                $this->flushPendingFileEvents($sessionId);
                 $this->emit('tool_result', ['name' => $tc['name'], 'result' => $result]);
 
                 $tDb = microtime(true);
@@ -590,6 +597,21 @@ class alfredAgent
             'mime_type' => $mimeType,
             'size'      => strlen($content),
         ];
+    }
+
+    /**
+     * Flush any file_added events queued by registerFile() (possibly from an external plugin process).
+     * Must be called from within the active agent turn so events reach the SSE stream.
+     */
+    private function flushPendingFileEvents(string $sessionId): void
+    {
+        $eventsFile = self::uploadDir($sessionId) . DIRECTORY_SEPARATOR . '_events.json';
+        if (!file_exists($eventsFile)) return;
+        $pending = json_decode(file_get_contents($eventsFile), true) ?: [];
+        unlink($eventsFile);
+        foreach ($pending as $ev) {
+            $this->emit('file_added', $ev);
+        }
     }
 
     /**

--- a/core/class/alfredLLM.class.php
+++ b/core/class/alfredLLM.class.php
@@ -113,17 +113,20 @@ class alfredLLM
         if ($apiKey   === '') $apiKey   = alfred::getApiKey($provider);
         if ($model    === '') $model    = alfred::getModel($provider);
 
-        if ($apiKey === '') {
-            throw new Exception("No API key configured for provider '{$provider}'.");
-        }
-
         switch ($provider) {
             case 'mistral':
+                if ($apiKey === '') throw new Exception("No API key configured for Mistral.");
                 require_once __DIR__ . '/alfredLLMMistralAdapter.class.php';
                 return new alfredLLMMistralAdapter($apiKey, $model);
             case 'gemini':
+                if ($apiKey === '') throw new Exception("No API key configured for Gemini.");
                 require_once __DIR__ . '/alfredLLMGeminiAdapter.class.php';
                 return new alfredLLMGeminiAdapter($apiKey, $model);
+            case 'ollama':
+                if ($apiKey === '') $apiKey = (string)config::byKey('ollama_base_url', 'alfred');
+                if ($apiKey === '') $apiKey = 'http://localhost:11434';
+                require_once __DIR__ . '/alfredLLMOllamaAdapter.class.php';
+                return new alfredLLMOllamaAdapter($apiKey, $model);
             default:
                 throw new Exception("Unknown LLM provider: '{$provider}'.");
         }

--- a/core/class/alfredLLMOllamaAdapter.class.php
+++ b/core/class/alfredLLMOllamaAdapter.class.php
@@ -1,0 +1,269 @@
+<?php
+
+class alfredLLMOllamaAdapter extends alfredLLMAdapter
+{
+    // $apiKey is repurposed to store the Ollama base URL (e.g. http://localhost:11434)
+
+    private function chatUrl(): string { return rtrim($this->apiKey, '/') . '/v1/chat/completions'; }
+    private function tagsUrl(): string { return rtrim($this->apiKey, '/') . '/api/tags'; }
+
+    public function chat(array $messages, array $tools, string $systemPrompt): array
+    {
+        $body = $this->buildBody($messages, $tools, $systemPrompt, false);
+        $data = $this->httpPost($this->chatUrl(), $this->headers(), $body, 120);
+        return $this->normalize($data);
+    }
+
+    public function chatStream(array $messages, array $tools, string $systemPrompt, callable $onDelta): array
+    {
+        $body        = $this->buildBody($messages, $tools, $systemPrompt, true);
+        $text        = '';
+        $tool_acc    = [];
+        $stop_reason = 'end_turn';
+        $buffer      = '';
+        $error_body  = '';
+
+        $ch = curl_init($this->chatUrl());
+        curl_setopt_array($ch, [
+            CURLOPT_POST           => true,
+            CURLOPT_POSTFIELDS     => json_encode($body),
+            CURLOPT_HTTPHEADER     => $this->headers(),
+            CURLOPT_TIMEOUT        => 120,
+            CURLOPT_SSL_VERIFYPEER => false,
+            CURLOPT_WRITEFUNCTION  => function ($ch, $raw) use (&$buffer, &$text, &$tool_acc, &$stop_reason, &$error_body, $onDelta) {
+                $buffer .= $raw;
+                while (($pos = strpos($buffer, "\n")) !== false) {
+                    $line   = trim(substr($buffer, 0, $pos));
+                    $buffer = substr($buffer, $pos + 1);
+
+                    if ($line === '' || $line === 'data: [DONE]') continue;
+                    if (substr($line, 0, 6) !== 'data: ') {
+                        $error_body .= $line;
+                        continue;
+                    }
+
+                    $d = json_decode(substr($line, 6), true);
+                    if (!is_array($d)) continue;
+
+                    if (isset($d['error'])) {
+                        $error_body = $d['error']['message'] ?? json_encode($d['error']);
+                        continue;
+                    }
+
+                    $choice = $d['choices'][0] ?? [];
+                    $delta  = $choice['delta'] ?? [];
+                    $finish = $choice['finish_reason'] ?? null;
+
+                    if ($finish === 'tool_calls') {
+                        $stop_reason = 'tool_use';
+                    }
+
+                    if (isset($delta['content']) && $delta['content'] !== '') {
+                        $chunk  = $delta['content'];
+                        $text  .= $chunk;
+                        $onDelta($chunk);
+                    }
+
+                    foreach ($delta['tool_calls'] ?? [] as $tc) {
+                        $idx = $tc['index'];
+                        if (!isset($tool_acc[$idx])) {
+                            $tool_acc[$idx] = ['id' => '', 'name' => '', 'arguments' => ''];
+                        }
+                        if (isset($tc['id']))                    $tool_acc[$idx]['id']        = $tc['id'];
+                        if (isset($tc['function']['name']))      $tool_acc[$idx]['name']      = $tc['function']['name'];
+                        if (isset($tc['function']['arguments'])) $tool_acc[$idx]['arguments'] .= $tc['function']['arguments'];
+                    }
+                }
+                return strlen($raw);
+            },
+        ]);
+
+        curl_exec($ch);
+        $code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        $err  = curl_error($ch);
+        curl_close($ch);
+
+        if ($err) {
+            throw new Exception("Cannot connect to Ollama: {$err}");
+        }
+        if ($code >= 400) {
+            if ($buffer !== '') $error_body .= trim($buffer);
+            if ($error_body !== '') {
+                $parsed = json_decode($error_body, true);
+                if (is_array($parsed)) {
+                    $error_body = $parsed['message'] ?? $parsed['error']['message'] ?? $error_body;
+                }
+            }
+            throw new Exception("Ollama error (HTTP {$code}): " . ($error_body ?: "HTTP {$code}"));
+        }
+
+        $tool_calls = [];
+        ksort($tool_acc);
+        foreach ($tool_acc as $tc) {
+            $tool_calls[] = [
+                'id'    => $tc['id'],
+                'name'  => $tc['name'],
+                'input' => json_decode($tc['arguments'], true) ?? [],
+            ];
+        }
+
+        return [
+            'text'        => trim($text),
+            'tool_calls'  => $tool_calls,
+            'stop_reason' => $stop_reason,
+        ];
+    }
+
+    public function testConnection(): array
+    {
+        $body = [
+            'model'      => $this->model,
+            'max_tokens' => 10,
+            'messages'   => [['role' => 'user', 'content' => 'Hi']],
+        ];
+        $this->httpPost($this->chatUrl(), $this->headers(), $body, 15);
+        return ['ok' => true, 'provider' => 'ollama', 'model' => $this->model];
+    }
+
+    public function listModels(): array
+    {
+        $ch = curl_init($this->tagsUrl());
+        curl_setopt_array($ch, [
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_TIMEOUT        => 10,
+            CURLOPT_SSL_VERIFYPEER => false,
+        ]);
+        $raw  = curl_exec($ch);
+        $code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        $err  = curl_error($ch);
+        curl_close($ch);
+
+        if ($err) {
+            throw new Exception("Cannot connect to Ollama at {$this->apiKey}: {$err}");
+        }
+        if ($code >= 400) {
+            throw new Exception("Ollama tags API error (HTTP {$code})");
+        }
+
+        $data = json_decode($raw, true);
+        if (!isset($data['models'])) {
+            return [];
+        }
+
+        $models = [];
+        foreach ($data['models'] as $m) {
+            $name = $m['name'] ?? '';
+            if ($name === '') continue;
+            $size      = $m['size'] ?? 0;
+            $sizeLabel = $size > 0 ? ' — ' . round($size / 1e9, 1) . ' GB' : '';
+            $models[]  = ['id' => $name, 'name' => $name . $sizeLabel];
+        }
+        usort($models, function ($a, $b) { return strcmp($a['id'], $b['id']); });
+        return $models;
+    }
+
+    // -------------------------------------------------------------------------
+
+    private function headers(): array
+    {
+        return ['Content-Type: application/json'];
+    }
+
+    private function buildBody(array $messages, array $tools, string $systemPrompt, bool $stream): array
+    {
+        $body = [
+            'model'    => $this->model,
+            'messages' => $this->toMessages($messages, $systemPrompt),
+            'stream'   => $stream,
+        ];
+        if (!empty($tools)) {
+            $body['tools'] = $this->toTools($tools);
+        }
+        return $body;
+    }
+
+    private function toMessages(array $messages, string $systemPrompt): array
+    {
+        $out = [];
+        if ($systemPrompt !== '') {
+            $out[] = ['role' => 'system', 'content' => $systemPrompt];
+        }
+        foreach ($messages as $msg) {
+            $role = $msg['role'];
+
+            if ($role === 'user') {
+                $out[] = ['role' => 'user', 'content' => $msg['content']];
+
+            } elseif ($role === 'assistant') {
+                $m = ['role' => 'assistant', 'content' => $msg['content'] ?? null];
+                if (!empty($msg['tool_calls'])) {
+                    $m['tool_calls'] = array_map(function ($tc) {
+                        return [
+                            'id'       => $tc['id'],
+                            'type'     => 'function',
+                            'function' => [
+                                'name'      => $tc['name'],
+                                'arguments' => json_encode($tc['input']),
+                            ],
+                        ];
+                    }, $msg['tool_calls']);
+                }
+                $out[] = $m;
+
+            } elseif ($role === 'tool') {
+                $out[] = [
+                    'role'         => 'tool',
+                    'tool_call_id' => $msg['tool_call_id'],
+                    'content'      => $msg['content'],
+                    'name'         => $msg['name'] ?? '',
+                ];
+            }
+        }
+        return $out;
+    }
+
+    private function toTools(array $tools): array
+    {
+        return array_map(function ($t) {
+            $schema = $t['inputSchema'] ?? ['type' => 'object', 'properties' => []];
+            return [
+                'type'     => 'function',
+                'function' => [
+                    'name'        => $t['name'],
+                    'description' => $t['description'] ?? '',
+                    'parameters'  => $schema,
+                ],
+            ];
+        }, $tools);
+    }
+
+    private function normalize(array $data): array
+    {
+        $choice     = $data['choices'][0] ?? [];
+        $message    = $choice['message'] ?? [];
+        $text       = $message['content'] ?? '';
+        $tool_calls = [];
+
+        foreach ($message['tool_calls'] ?? [] as $tc) {
+            $input        = json_decode($tc['function']['arguments'] ?? '{}', true) ?? [];
+            $tool_calls[] = [
+                'id'    => $tc['id'],
+                'name'  => $tc['function']['name'],
+                'input' => $input,
+            ];
+        }
+
+        $finishReason = $choice['finish_reason'] ?? 'stop';
+        $u            = $data['usage'] ?? [];
+
+        return [
+            'text'        => trim((string)$text),
+            'tool_calls'  => $tool_calls,
+            'stop_reason' => $finishReason === 'tool_calls' ? 'tool_use' : 'end_turn',
+            'usage'       => [
+                'input_tokens'  => (int)($u['prompt_tokens']     ?? 0),
+                'output_tokens' => (int)($u['completion_tokens'] ?? 0),
+            ],
+        ];
+    }
+}

--- a/core/class/alfredLLMOllamaAdapter.class.php
+++ b/core/class/alfredLLMOllamaAdapter.class.php
@@ -231,10 +231,36 @@ class alfredLLMOllamaAdapter extends alfredLLMAdapter
                 'function' => [
                     'name'        => $t['name'],
                     'description' => $t['description'] ?? '',
-                    'parameters'  => $schema,
+                    'parameters'  => $this->normalizeSchemaForJson($schema),
                 ],
             ];
         }, $tools);
+    }
+
+    // json_decode($json, true) turns {} into [] in PHP; re-encoding gives [] instead of {}.
+    // This recursively converts empty/assoc arrays to stdClass so they encode as JSON objects.
+    private static $JSON_ARRAY_KEYS = ['required', 'enum', 'anyOf', 'oneOf', 'allOf', 'not'];
+
+    private function normalizeSchemaForJson($value, string $parentKey = '')
+    {
+        if (!is_array($value)) {
+            return $value;
+        }
+        if (in_array($parentKey, self::$JSON_ARRAY_KEYS, true)) {
+            return array_map(function ($v) { return $this->normalizeSchemaForJson($v); }, $value);
+        }
+        if (empty($value)) {
+            return new stdClass();
+        }
+        $keys = array_keys($value);
+        if ($keys === range(0, count($keys) - 1)) {
+            return array_map(function ($v) { return $this->normalizeSchemaForJson($v); }, $value);
+        }
+        $obj = new stdClass();
+        foreach ($value as $k => $v) {
+            $obj->$k = $this->normalizeSchemaForJson($v, $k);
+        }
+        return $obj;
     }
 
     private function normalize(array $data): array

--- a/docs/llm-providers.md
+++ b/docs/llm-providers.md
@@ -1,0 +1,105 @@
+# Fournisseurs LLM
+
+Alfred supporte plusieurs fournisseurs de modèles de langage. Le fournisseur actif se choisit dans **Plugins → Alfred → Configuration → Fournisseur IA**.
+
+---
+
+## Mistral AI
+
+Fournisseur cloud de modèles open-weight (Mistral 7B, Mistral Large, etc.).
+
+**Prérequis**
+- Compte sur [console.mistral.ai](https://console.mistral.ai)
+- Clé API générée depuis l'espace *API keys*
+
+**Configuration**
+| Champ | Valeur |
+|---|---|
+| Fournisseur | `Mistral AI` |
+| Clé API | Clé `sk-...` copiée depuis la console |
+| Modèle | Sélectionner dans la liste (chargée automatiquement au clic) |
+
+**Modèles recommandés**
+- `mistral-large-latest` — meilleur niveau de raisonnement, recommandé pour l'agentique
+- `mistral-small-latest` — plus rapide et moins coûteux pour les usages simples
+
+**Tool calling** : supporté sur tous les modèles `mistral-large` et `mistral-small`.
+
+---
+
+## Google Gemini
+
+Fournisseur cloud Google (famille Gemini 1.5 / 2.0).
+
+**Prérequis**
+- Projet Google Cloud avec l'API *Generative Language* activée
+- Clé API depuis [aistudio.google.com](https://aistudio.google.com) ou Google Cloud Console
+
+**Configuration**
+| Champ | Valeur |
+|---|---|
+| Fournisseur | `Google (Gemini)` |
+| Clé API | Clé `AIza...` |
+| Modèle | Sélectionner dans la liste |
+
+**Modèles recommandés**
+- `gemini-1.5-pro` — contexte long (1 M tokens), bon pour les conversations complexes
+- `gemini-2.0-flash` — rapide et économique
+
+**Tool calling** : supporté. Note : Gemini ne supporte pas nativement le streaming avec tool calling — Alfred simule le streaming en découpant la réponse.
+
+---
+
+## Ollama (local)
+
+Exécution de modèles open-source **en local** sur votre propre machine ou réseau. Aucune donnée n'est envoyée à un service externe.
+
+**Prérequis**
+- [Ollama](https://ollama.com) installé et en cours d'exécution
+- Au moins un modèle téléchargé (`ollama pull mistral`)
+- Ollama accessible depuis le serveur Jeedom (même réseau local)
+
+**Installation rapide (Windows)**
+```powershell
+# Installer depuis ollama.com, puis :
+ollama pull mistral       # télécharge Mistral 7B (~4 GB)
+ollama pull llama3.1      # alternative : Llama 3.1 8B
+```
+
+**Exposer Ollama sur le réseau local**
+
+Par défaut, Ollama écoute uniquement sur `localhost`. Pour le rendre accessible depuis Jeedom (sur un autre appareil) :
+
+```powershell
+# Variable système (persistante après reboot)
+[System.Environment]::SetEnvironmentVariable("OLLAMA_HOST", "0.0.0.0:11434", "Machine")
+# Puis redémarrer Ollama
+```
+
+**Configuration dans Alfred**
+| Champ | Valeur |
+|---|---|
+| Fournisseur | `Ollama (local)` |
+| URL Ollama | `http://<IP_DE_LA_MACHINE>:11434` (ex: `http://192.168.1.50:11434`) |
+| Modèle | Cliquer sur la liste pour charger les modèles installés |
+
+**Modèles recommandés**
+
+| Modèle | VRAM nécessaire | Tool calling | Notes |
+|---|---|---|---|
+| `mistral` | ~5 GB (Q4) | Oui | Bon équilibre qualité/vitesse |
+| `llama3.1` | ~5 GB (Q4) | Oui | Très bon pour l'agentique |
+| `qwen2.5` | ~5 GB (Q4) | Oui | Multilingue, bon en français |
+| `phi3` | ~2 GB | Non | Ultra-léger, pas de tool calling |
+
+> Le tool calling (indispensable pour l'agentique Alfred/MCP) n'est supporté que par certains modèles. Préférer `mistral`, `llama3.1` ou `qwen2.5`.
+
+**Vérifier que Ollama tourne**
+```
+curl http://localhost:11434
+# Réponse attendue : Ollama is running
+```
+
+**Limitations**
+- Vitesse d'inférence dépendante du matériel local (GPU recommandé)
+- Pas d'authentification native — ne pas exposer publiquement sans reverse proxy sécurisé

--- a/plugin_info/configuration.php
+++ b/plugin_info/configuration.php
@@ -35,6 +35,7 @@ $_js_i18n = [
 $_providers = [
     'mistral' => 'Mistral AI',
     'gemini'  => 'Google (Gemini)',
+    'ollama'  => 'Ollama (local)',
 ];
 
 // Auto-detect JeedomMCP settings (used for add button default URL)
@@ -111,6 +112,28 @@ $_mcpServersJson = is_array($_mcpRaw) ? (json_encode($_mcpRaw) ?: '[]') : ($_mcp
                         <option value="<?php echo htmlspecialchars($_saved); ?>"><?php echo htmlspecialchars($_saved ?: '—'); ?></option>
                     </select>
                 </div>
+            </div>
+        </div>
+
+        <!-- Ollama -->
+        <div class="alfred-provider-section" data-provider="ollama">
+            <div class="form-group">
+                <label class="col-sm-4 control-label">{{Ollama URL}}</label>
+                <div class="col-sm-4">
+                    <input type="text" class="configKey form-control alfred-api-key" data-l1key="ollama_base_url"
+                           placeholder="http://192.168.1.X:11434" />
+                </div>
+                <span class="help-block col-sm-4">{{Base URL of your local Ollama instance.}}</span>
+            </div>
+            <div class="form-group">
+                <label class="col-sm-4 control-label">{{Model}}</label>
+                <div class="col-sm-4">
+                    <select class="configKey form-control alfred-model-select" data-l1key="ollama_model">
+                        <?php $_saved = config::byKey('ollama_model', 'alfred'); ?>
+                        <option value="<?php echo htmlspecialchars($_saved); ?>"><?php echo htmlspecialchars($_saved ?: '—'); ?></option>
+                    </select>
+                </div>
+                <span class="help-block col-sm-4">{{Click to load available models from Ollama.}}</span>
             </div>
         </div>
 
@@ -631,7 +654,8 @@ var _alfredPollCount = 0;
 var _alfredProviderPoll = setInterval(function () {
     _alfredPollCount++;
     var hasKey = !!($('[data-l1key="mistral_api_key"]').val()
-                  || $('[data-l1key="gemini_api_key"]').val());
+                  || $('[data-l1key="gemini_api_key"]').val()
+                  || $('[data-l1key="ollama_base_url"]').val());
     if (hasKey || _alfredPollCount >= 20) {
         clearInterval(_alfredProviderPoll);
         alfredShowProvider($('#alfred_provider').val());
@@ -910,7 +934,8 @@ $('#bt_alfred_test_llm').on('click', function () {
     var model     = $section.find('.alfred-model-select').val();
 
     if (!apiKey) {
-        $result.html('<span style="color:#a94442"><i class="fas fa-times"></i> ' + _alfredI18n.enter_api_key + '</span>');
+        var _missingMsg = (provider === 'ollama') ? '{{Enter the Ollama URL first.}}' : _alfredI18n.enter_api_key;
+        $result.html('<span style="color:#a94442"><i class="fas fa-times"></i> ' + _missingMsg + '</span>');
         return;
     }
 

--- a/plugin_info/configuration.php
+++ b/plugin_info/configuration.php
@@ -672,13 +672,13 @@ var _alfredModelsLoaded = {};
 function alfredLoadModels($section) {
     var provider = $section.data('provider');
     if (_alfredModelsLoaded[provider]) return;
-    _alfredModelsLoaded[provider] = true;
 
     var $select  = $section.find('.alfred-model-select');
     var apiKey   = $section.find('.alfred-api-key').val().trim();
     var savedVal = $select.val();
 
     if (!apiKey) return;
+    _alfredModelsLoaded[provider] = true;
 
     $select.empty().append($('<option>').val('').text(_alfredI18n.loading).prop('disabled', true).prop('selected', true));
     $select.prop('disabled', true);
@@ -716,6 +716,13 @@ function alfredLoadModels($section) {
 
 $(document).on('mousedown', '.alfred-model-select', function () {
     alfredLoadModels($(this).closest('.alfred-provider-section'));
+});
+
+// For Ollama, also load models when the URL field loses focus
+$(document).on('blur', '.alfred-provider-section[data-provider="ollama"] .alfred-api-key', function () {
+    var $section = $(this).closest('.alfred-provider-section');
+    _alfredModelsLoaded['ollama'] = false; // reset so we reload with the new URL
+    alfredLoadModels($section);
 });
 
 // ---- Memory management ----


### PR DESCRIPTION
Closes #32

## Summary
- New `alfredLLMOllamaAdapter` — OpenAI-compatible API, full streaming SSE, tool calling
- Factory updated: Ollama needs no API key, uses configurable base URL (defaults to `http://localhost:11434`)
- Config UI: URL field + model dropdown (lazy-loaded from `/api/tags`)
- `docs/llm-providers.md`: reference docs for all three providers (Mistral, Gemini, Ollama)

## Test plan
- [ ] Sélectionner `Ollama (local)` dans la config Alfred
- [ ] Saisir l'URL (`http://192.168.1.X:11434`), cliquer sur le select modèle → liste chargée
- [ ] Bouton "Test LLM connection" → OK
- [ ] Envoyer un message dans le chat → réponse en streaming
- [ ] Tester un tool call (ex: "allume la lumière du salon") → tool calling fonctionnel
- [ ] Vérifier que Mistral et Gemini fonctionnent toujours