### PR TITLE
feat(llm): track provider, model and token usage per LLM call

### DIFF
--- a/core/class/alfredAgent.class.php
+++ b/core/class/alfredAgent.class.php
@@ -395,35 +395,71 @@ class alfredAgent
         }
 
         // ReAct loop
-        $finalText  = '';
-        $iterations = 0;
+        $finalText    = '';
+        $iterations   = 0;
+        $systemChars  = strlen($effectiveSystemPrompt);
+        $toolsChars   = strlen(json_encode($tools));
+        $prevMsgChars = strlen(json_encode($messages));
+        $llmProvider  = $this->llm->getProvider();
+        $llmModel     = $this->llm->getModel();
 
         while ($iterations < $this->maxIterations) {
             $iterations++;
 
+            $currentMsgChars = strlen(json_encode($messages));
+            $newResChars     = max(0, $currentMsgChars - $prevMsgChars);
+
             $onDelta  = function (string $chunk): void {
                 $this->emit('delta', ['text' => $chunk]);
             };
-            $tLlm     = microtime(true);
-            $response = $this->llm->chatStream($messages, $tools, $effectiveSystemPrompt, $onDelta);
+            $tLlm       = microtime(true);
+            $response   = $this->llm->chatStream($messages, $tools, $effectiveSystemPrompt, $onDelta);
+            $durationMs = (int)round((microtime(true) - $tLlm) * 1000);
             $timing['llm_calls'][] = [
                 'iteration'   => $iterations,
-                'duration_ms' => (int)round((microtime(true) - $tLlm) * 1000),
+                'duration_ms' => $durationMs,
             ];
+
+            $llmInfo = ['provider' => $llmProvider, 'model' => $llmModel];
 
             if ($response['stop_reason'] === 'end_turn' || empty($response['tool_calls'])) {
                 // Final text response — delta events were already emitted chunk by chunk
                 $finalText = $response['text'];
                 $tDb = microtime(true);
-                alfredConversation::saveAssistantResponse($sessionId, $response);
+                $msgId = alfredConversation::saveAssistantResponse($sessionId, $response, $llmInfo);
                 $timing['db_writes'] += (int)round((microtime(true) - $tDb) * 1000);
+                alfredConversation::saveLlmCall($sessionId, $msgId, [
+                    'iteration'     => $iterations,
+                    'provider'      => $llmProvider,
+                    'model'         => $llmModel,
+                    'input_tokens'  => $response['usage']['input_tokens']  ?? 0,
+                    'output_tokens' => $response['usage']['output_tokens'] ?? 0,
+                    'duration_ms'   => $durationMs,
+                    'system_chars'  => $systemChars,
+                    'history_chars' => $currentMsgChars,
+                    'tools_chars'   => $toolsChars,
+                    'new_res_chars' => $newResChars,
+                ]);
                 break;
             }
 
             // Assistant wants to call tools — persist the assistant turn first
             $tDb = microtime(true);
-            alfredConversation::saveAssistantResponse($sessionId, $response);
+            $msgId = alfredConversation::saveAssistantResponse($sessionId, $response, $llmInfo);
             $timing['db_writes'] += (int)round((microtime(true) - $tDb) * 1000);
+            alfredConversation::saveLlmCall($sessionId, $msgId, [
+                'iteration'     => $iterations,
+                'provider'      => $llmProvider,
+                'model'         => $llmModel,
+                'input_tokens'  => $response['usage']['input_tokens']  ?? 0,
+                'output_tokens' => $response['usage']['output_tokens'] ?? 0,
+                'duration_ms'   => $durationMs,
+                'system_chars'  => $systemChars,
+                'history_chars' => $currentMsgChars,
+                'tools_chars'   => $toolsChars,
+                'new_res_chars' => $newResChars,
+            ]);
+            $prevMsgChars = $currentMsgChars;
 
             // Add to in-memory messages for next iteration
             $assistantMsg = [

--- a/core/class/alfredConversation.class.php
+++ b/core/class/alfredConversation.class.php
@@ -106,7 +106,7 @@ class alfredConversation
      * @param mixed  $content  String or array (will be JSON-encoded)
      * @param array  $metadata Optional extra data (tool_call_id, tool_calls, name…)
      */
-    public static function addMessage(string $sessionId, string $role, $content, array $metadata = []): void
+    public static function addMessage(string $sessionId, string $role, $content, array $metadata = []): int
     {
         $contentStr  = is_array($content) ? json_encode($content, JSON_UNESCAPED_UNICODE) : (string)$content;
         $metadataStr = empty($metadata)   ? null : json_encode($metadata, JSON_UNESCAPED_UNICODE);
@@ -123,7 +123,11 @@ class alfredConversation
             DB::FETCH_TYPE_ROW
         );
 
+        $row = DB::Prepare('SELECT LAST_INSERT_ID() AS id', [], DB::FETCH_TYPE_ROW);
+        $id  = isset($row['id']) ? (int)$row['id'] : 0;
+
         self::touchSession($sessionId);
+        return $id;
     }
 
     /**
@@ -209,9 +213,11 @@ class alfredConversation
     /**
      * Persist a full normalized LLM response into the session.
      *
-     * $response = ['text' => '...', 'tool_calls' => [...], 'stop_reason' => '...']
+     * $response  = ['text' => '...', 'tool_calls' => [...], 'stop_reason' => '...', 'usage' => [...]]
+     * $llmInfo   = ['provider' => '...', 'model' => '...']  (optional, stored in metadata)
+     * Returns the new message id.
      */
-    public static function saveAssistantResponse(string $sessionId, array $response): void
+    public static function saveAssistantResponse(string $sessionId, array $response, array $llmInfo = []): int
     {
         $meta = [];
         if (!empty($response['tool_calls'])) {
@@ -220,7 +226,48 @@ class alfredConversation
         if (!empty($response['gemini_thought_parts'])) {
             $meta['gemini_thought_parts'] = $response['gemini_thought_parts'];
         }
-        self::addMessage($sessionId, 'assistant', $response['text'], $meta);
+        if (!empty($llmInfo['provider'])) {
+            $meta['provider'] = $llmInfo['provider'];
+        }
+        if (!empty($llmInfo['model'])) {
+            $meta['model'] = $llmInfo['model'];
+        }
+        return self::addMessage($sessionId, 'assistant', $response['text'], $meta);
+    }
+
+    /**
+     * Persist one LLM API call's metrics into alfred_llm_call.
+     *
+     * $data keys: iteration, provider, model, input_tokens, output_tokens,
+     *             duration_ms, system_chars, history_chars, tools_chars, new_res_chars
+     */
+    public static function saveLlmCall(string $sessionId, ?int $messageId, array $data): void
+    {
+        DB::Prepare(
+            'INSERT INTO alfred_llm_call
+             (session_id, message_id, iteration, provider, model,
+              input_tokens, output_tokens, duration_ms,
+              system_chars, history_chars, tools_chars, new_res_chars)
+             VALUES
+             (:session_id, :message_id, :iteration, :provider, :model,
+              :input_tokens, :output_tokens, :duration_ms,
+              :system_chars, :history_chars, :tools_chars, :new_res_chars)',
+            [
+                ':session_id'    => $sessionId,
+                ':message_id'    => $messageId ?: null,
+                ':iteration'     => (int)($data['iteration']     ?? 1),
+                ':provider'      => (string)($data['provider']   ?? ''),
+                ':model'         => (string)($data['model']      ?? ''),
+                ':input_tokens'  => (int)($data['input_tokens']  ?? 0),
+                ':output_tokens' => (int)($data['output_tokens'] ?? 0),
+                ':duration_ms'   => (int)($data['duration_ms']   ?? 0),
+                ':system_chars'  => (int)($data['system_chars']  ?? 0),
+                ':history_chars' => (int)($data['history_chars'] ?? 0),
+                ':tools_chars'   => (int)($data['tools_chars']   ?? 0),
+                ':new_res_chars' => (int)($data['new_res_chars'] ?? 0),
+            ],
+            DB::FETCH_TYPE_ROW
+        );
     }
 
     /**

--- a/core/class/alfredLLM.class.php
+++ b/core/class/alfredLLM.class.php
@@ -32,6 +32,13 @@ abstract class alfredLLMAdapter
         $this->model  = $model;
     }
 
+    abstract public function getProvider(): string;
+
+    public function getModel(): string
+    {
+        return $this->model;
+    }
+
     /**
      * Send a conversation turn to the LLM.
      *

--- a/core/class/alfredLLMGeminiAdapter.class.php
+++ b/core/class/alfredLLMGeminiAdapter.class.php
@@ -5,6 +5,8 @@ class alfredLLMGeminiAdapter extends alfredLLMAdapter
     private const API_BASE   = 'https://generativelanguage.googleapis.com/v1beta/models';
     private const MODELS_URL = 'https://generativelanguage.googleapis.com/v1beta/models';
 
+    public function getProvider(): string { return 'gemini'; }
+
     public function chat(array $messages, array $tools, string $systemPrompt): array
     {
         $url  = self::API_BASE . '/' . urlencode($this->model) . ':generateContent?key=' . urlencode($this->apiKey);

--- a/core/class/alfredLLMMistralAdapter.class.php
+++ b/core/class/alfredLLMMistralAdapter.class.php
@@ -5,6 +5,8 @@ class alfredLLMMistralAdapter extends alfredLLMAdapter
     private const API_URL    = 'https://api.mistral.ai/v1/chat/completions';
     private const MODELS_URL = 'https://api.mistral.ai/v1/models';
 
+    public function getProvider(): string { return 'mistral'; }
+
     public function chat(array $messages, array $tools, string $systemPrompt): array
     {
         $mistralMessages = [];

--- a/core/class/alfredLLMMistralAdapter.class.php
+++ b/core/class/alfredLLMMistralAdapter.class.php
@@ -52,6 +52,7 @@ class alfredLLMMistralAdapter extends alfredLLMAdapter
         $text        = '';
         $tool_acc    = []; // index => ['id', 'name', 'arguments']
         $stop_reason = 'end_turn';
+        $usage       = [];
         $buffer      = '';
         $error_body  = '';
 
@@ -62,7 +63,7 @@ class alfredLLMMistralAdapter extends alfredLLMAdapter
             CURLOPT_HTTPHEADER     => $this->headers(),
             CURLOPT_TIMEOUT        => 120,
             CURLOPT_SSL_VERIFYPEER => true,
-            CURLOPT_WRITEFUNCTION  => function ($ch, $raw) use (&$buffer, &$text, &$tool_acc, &$stop_reason, &$error_body, $onDelta) {
+            CURLOPT_WRITEFUNCTION  => function ($ch, $raw) use (&$buffer, &$text, &$tool_acc, &$stop_reason, &$usage, &$error_body, $onDelta) {
                 $buffer .= $raw;
                 while (($pos = strpos($buffer, "\n")) !== false) {
                     $line   = trim(substr($buffer, 0, $pos));
@@ -80,6 +81,10 @@ class alfredLLMMistralAdapter extends alfredLLMAdapter
                     if (isset($d['error'])) {
                         $error_body = $d['error']['message'] ?? json_encode($d['error']);
                         continue;
+                    }
+
+                    if (isset($d['usage'])) {
+                        $usage = $d['usage'];
                     }
 
                     $choice = $d['choices'][0] ?? [];
@@ -148,6 +153,10 @@ class alfredLLMMistralAdapter extends alfredLLMAdapter
             'text'        => trim($text),
             'tool_calls'  => $tool_calls,
             'stop_reason' => $stop_reason,
+            'usage'       => [
+                'input_tokens'  => (int)($usage['prompt_tokens']     ?? 0),
+                'output_tokens' => (int)($usage['completion_tokens'] ?? 0),
+            ],
         ];
     }
 

--- a/core/class/alfredMigration.class.php
+++ b/core/class/alfredMigration.class.php
@@ -7,12 +7,13 @@ class alfredMigration
         2 => 'migration_002_memory_label',
         3 => 'migration_003_repair_schema',
         4 => 'migration_004_conversation_user_login',
+        5 => 'migration_005_llm_call_tracking',
     ];
 
     public static function runPending()
     {
         // Reset version if any required table is missing (all migrations are idempotent)
-        $required = ['alfred_message', 'alfred_conversation', 'alfred_memory', 'alfred_schedule'];
+        $required = ['alfred_message', 'alfred_conversation', 'alfred_memory', 'alfred_schedule', 'alfred_llm_call'];
         foreach ($required as $table) {
             $row = DB::Prepare(
                 "SELECT COUNT(*) as cnt FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = :tbl",
@@ -109,6 +110,29 @@ class alfredMigration
                 [], DB::FETCH_TYPE_ROW
             );
         }
+    }
+
+    private static function migration_005_llm_call_tracking()
+    {
+        DB::Prepare('CREATE TABLE IF NOT EXISTS `alfred_llm_call` (
+            `id`            INT UNSIGNED     NOT NULL AUTO_INCREMENT,
+            `session_id`    VARCHAR(36)      NOT NULL,
+            `message_id`    INT UNSIGNED     DEFAULT NULL,
+            `iteration`     TINYINT UNSIGNED NOT NULL DEFAULT 1,
+            `provider`      VARCHAR(50)      NOT NULL DEFAULT \'\',
+            `model`         VARCHAR(100)     NOT NULL DEFAULT \'\',
+            `input_tokens`  INT UNSIGNED     NOT NULL DEFAULT 0,
+            `output_tokens` INT UNSIGNED     NOT NULL DEFAULT 0,
+            `duration_ms`   INT UNSIGNED     NOT NULL DEFAULT 0,
+            `system_chars`  INT UNSIGNED     NOT NULL DEFAULT 0,
+            `history_chars` INT UNSIGNED     NOT NULL DEFAULT 0,
+            `tools_chars`   INT UNSIGNED     NOT NULL DEFAULT 0,
+            `new_res_chars` INT UNSIGNED     NOT NULL DEFAULT 0,
+            `created_at`    DATETIME         NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY (`id`),
+            KEY `idx_session` (`session_id`),
+            KEY `idx_message` (`message_id`)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', [], DB::FETCH_TYPE_ROW);
     }
 
     private static function migration_004_conversation_user_login()


### PR DESCRIPTION
Closes #35

## Summary

- New table `alfred_llm_call` (migration #5): one row per API call in the ReAct loop with `input_tokens`, `output_tokens`, `duration_ms` and char-count breakdown (`system_chars`, `history_chars`, `tools_chars`, `new_res_chars`)
- `alfred_message.metadata` now includes `provider` and `model` on each assistant message
- `alfredLLMAdapter` gains `getProvider()` (abstract) and `getModel()` methods
- `alfredConversation::addMessage()` now returns the insert ID; `saveAssistantResponse()` accepts `$llmInfo` and returns the message ID; new `saveLlmCall()` method
- Agent loop captures metrics per iteration and links each call to its resulting message

## Test plan

- [ ] Send a message to Alfred — check `alfred_llm_call` has one row with non-zero `input_tokens`
- [ ] Send a message that triggers tool use — check multiple rows (one per iteration) with growing `history_chars`
- [ ] Check `alfred_message.metadata` for `provider` and `model` fields on assistant messages
- [ ] Verify migration runs on a fresh install (no `alfred_llm_call` table before)