### PR TITLE
feat(async): unified async task table with pending UI feedback

### DIFF
--- a/api/chat.php
+++ b/api/chat.php
@@ -59,7 +59,7 @@ require_once __DIR__ . '/../core/class/alfredLLM.class.php';
 require_once __DIR__ . '/../core/class/alfredMCP.class.php';
 require_once __DIR__ . '/../core/class/alfredMCPRegistry.class.php';
 require_once __DIR__ . '/../core/class/alfredConversation.class.php';
-require_once __DIR__ . '/../core/class/alfredScheduler.class.php';
+require_once __DIR__ . '/../core/class/alfredAsyncTask.class.php';
 require_once __DIR__ . '/../core/class/alfredMemory.class.php';
 require_once __DIR__ . '/../core/class/alfredAgent.class.php';
 

--- a/api/conversation.php
+++ b/api/conversation.php
@@ -67,7 +67,7 @@ require_once __DIR__ . '/../core/class/alfredLLM.class.php';
 require_once __DIR__ . '/../core/class/alfredMCP.class.php';
 require_once __DIR__ . '/../core/class/alfredMCPRegistry.class.php';
 require_once __DIR__ . '/../core/class/alfredConversation.class.php';
-require_once __DIR__ . '/../core/class/alfredScheduler.class.php';
+require_once __DIR__ . '/../core/class/alfredAsyncTask.class.php';
 require_once __DIR__ . '/../core/class/alfredMemory.class.php';
 require_once __DIR__ . '/../core/class/alfredAgent.class.php';
 

--- a/api/wakeup.php
+++ b/api/wakeup.php
@@ -1,16 +1,12 @@
 <?php
 /**
- * Alfred wakeup script — called by the background scheduler after a delay.
+ * Alfred async task wakeup script — called by the background scheduler after a delay.
  *
  * CLI only. Usage:
- *   php wakeup.php --schedule_id=N --delay=N
+ *   php wakeup.php --task_id=N --delay=N
  *
- * The script sleeps for --delay seconds (0 means no sleep), then loads the
- * schedule row from the DB and runs the agent with a synthetic user message:
- *   "[SCHEDULED] {instruction}"
- *
- * The schedule row is updated to 'running' before the agent starts and to
- * 'done' or 'error' afterward, preventing duplicate executions.
+ * Sleeps for --delay seconds, then loads the task from alfred_async_task and
+ * executes it. Marks the task running before execution, then done or error after.
  */
 
 if (php_sapi_name() !== 'cli') {
@@ -19,12 +15,12 @@ if (php_sapi_name() !== 'cli') {
 }
 
 // ---- Parse arguments ----
-$opts       = getopt('', ['schedule_id:', 'delay:']);
-$scheduleId = (int)($opts['schedule_id'] ?? 0);
-$delay      = (int)($opts['delay']       ?? 0);
+$opts   = getopt('', ['task_id:', 'delay:']);
+$taskId = (int)($opts['task_id'] ?? 0);
+$delay  = (int)($opts['delay']   ?? 0);
 
-if ($scheduleId <= 0) {
-    fwrite(STDERR, "wakeup.php: --schedule_id is required and must be a positive integer\n");
+if ($taskId <= 0) {
+    fwrite(STDERR, "wakeup.php: --task_id is required and must be a positive integer\n");
     exit(1);
 }
 
@@ -42,31 +38,30 @@ require_once __DIR__ . '/../core/class/alfredLLM.class.php';
 require_once __DIR__ . '/../core/class/alfredMCP.class.php';
 require_once __DIR__ . '/../core/class/alfredMCPRegistry.class.php';
 require_once __DIR__ . '/../core/class/alfredConversation.class.php';
-require_once __DIR__ . '/../core/class/alfredScheduler.class.php';
+require_once __DIR__ . '/../core/class/alfredAsyncTask.class.php';
 require_once __DIR__ . '/../core/class/alfredMemory.class.php';
 require_once __DIR__ . '/../core/class/alfredAgent.class.php';
 
-// ---- Load schedule row ----
-$row = DB::Prepare(
-    'SELECT * FROM alfred_schedule WHERE id = :id LIMIT 1',
-    [':id' => $scheduleId],
-    DB::FETCH_TYPE_ROW
-) ?: null;
+// ---- Load task ----
+$task = alfredAsyncTask::getTask($taskId);
 
-if ($row === null) {
-    log::add('alfred_cron', 'error', "schedule #{$scheduleId}: row not found");
+if ($task === null) {
+    log::add('alfred_cron', 'error', "wakeup: task #{$taskId} not found");
     exit(1);
 }
 
-if ($row['status'] !== 'pending') {
+if ($task['status'] !== 'pending') {
     // Already executed or cancelled — exit silently to prevent duplicates
     exit(0);
 }
 
-log::add('alfred_cron', 'info', "=== schedule #{$scheduleId} starting: {$row['instruction']} ===");
+$payload     = json_decode($task['payload'] ?? '{}', true);
+$instruction = $payload['instruction'] ?? '';
+
+log::add('alfred_cron', 'info', "=== wakeup task #{$taskId} starting: {$instruction} ===");
 
 // ---- Resolve user from session ----
-$userLogin  = alfredConversation::getUserLogin($row['session_id']);
+$userLogin  = alfredConversation::getUserLogin($task['session_id']);
 $userProfil = null;
 if ($userLogin !== null) {
     try {
@@ -74,18 +69,18 @@ if ($userLogin !== null) {
         $userProfil = ($u && $u->getProfils() === 'admin') ? 'admin' : 'user';
     } catch (Exception $ignored) {}
 }
-log::add('alfred_cron', 'info', "schedule #{$scheduleId}: user={$userLogin}, session={$row['session_id']}");
+log::add('alfred_cron', 'info', "wakeup task #{$taskId}: user={$userLogin}, session={$task['session_id']}");
 
-// ---- Run agent ----
-alfredScheduler::markRunning($scheduleId);
+// ---- Run ----
+alfredAsyncTask::markRunning($taskId);
 
 try {
     $agent = new alfredAgent(null, null, null, $userLogin, $userProfil);
-    $agent->run($row['session_id'], '[SCHEDULED] ' . $row['instruction']);
-    alfredScheduler::markDone($scheduleId);
-    log::add('alfred_cron', 'info', "=== schedule #{$scheduleId} done ===");
+    $agent->run($task['session_id'], '[SCHEDULED] ' . $instruction);
+    alfredAsyncTask::resolve($taskId);
+    log::add('alfred_cron', 'info', "=== wakeup task #{$taskId} done ===");
 } catch (Exception $e) {
-    alfredScheduler::markError($scheduleId, $e->getMessage());
-    log::add('alfred_cron', 'error', "schedule #{$scheduleId} failed: " . $e->getMessage());
+    alfredAsyncTask::fail($taskId, $e->getMessage());
+    log::add('alfred_cron', 'error', "wakeup task #{$taskId} failed: " . $e->getMessage());
     exit(1);
 }

--- a/chat/index.php
+++ b/chat/index.php
@@ -1126,6 +1126,7 @@ $(function () {
 
     function renderHistory(messages) {
         knownMsgCount = messages.length;
+        _toolCallMap  = {};
         $('#alfred-messages').empty();
         var toolInputMap = {};
         messages.forEach(function (msg, idx) {
@@ -1571,6 +1572,11 @@ $(function () {
             var d = JSON.parse(e.data); updateToolCall(d.name, 'done', d.result);
         });
 
+        source.addEventListener('async_task', function (e) {
+            var d = JSON.parse(e.data);
+            appendAsyncTask({ display_text: d.display_text, async_status: d.async_status, task_id: d.task_id });
+        });
+
         source.addEventListener('file_added', function (e) {
             var f = JSON.parse(e.data);
             if (!pendingFiles.some(function (pf) { return pf.file_id === f.file_id; })) {
@@ -1714,7 +1720,7 @@ $(function () {
         }
         if (hasResult) {
             var rstr = typeof result === 'string' ? result : JSON.stringify(result, null, 2);
-            $details.append($('<div class="alfred-tool-section">')
+            $details.append($('<div class="alfred-tool-section alfred-tool-result-section">')
                 .append($('<span class="alfred-tool-label">').text('Result'))
                 .append($('<pre class="alfred-tool-pre">').text(rstr)));
         }
@@ -1729,9 +1735,12 @@ $(function () {
         if (!$el) return;
         $el.find('i').attr('class', 'fas ' + (status === 'done' ? 'fa-check text-success' : 'fa-times text-danger'));
         if (result !== undefined && result !== null) {
-            var rstr     = typeof result === 'string' ? result : JSON.stringify(result, null, 2);
-            var $details = $el.find('.alfred-tool-details').removeClass('alfred-tool-no-content');
-            $details.append($('<div class="alfred-tool-section">')
+            var $details = $el.find('.alfred-tool-details');
+            // Guard: only append result section if none exists yet
+            if ($details.find('.alfred-tool-result-section').length > 0) return;
+            var rstr = typeof result === 'string' ? result : JSON.stringify(result, null, 2);
+            $details.removeClass('alfred-tool-no-content');
+            $details.append($('<div class="alfred-tool-section alfred-tool-result-section">')
                 .append($('<span class="alfred-tool-label">').text('Result'))
                 .append($('<pre class="alfred-tool-pre">').text(rstr)));
         }

--- a/chat/index.php
+++ b/chat/index.php
@@ -1139,9 +1139,8 @@ $(function () {
                     }
                 }
             } else if (msg.role === 'user') {
-                if (msg.content.indexOf('[SCHEDULED]') === 0) {
-                    appendScheduledBubble(msg.content.replace('[SCHEDULED]', '').trim());
-                } else {
+                // [SCHEDULED] messages are shown via their pending task bubble — skip duplicate
+                if (msg.content.indexOf('[SCHEDULED]') !== 0) {
                     appendBubble('user', msg.content);
                 }
             } else if (msg.role === 'tool') {
@@ -1149,6 +1148,8 @@ $(function () {
                 var result;
                 try { result = JSON.parse(msg.content); } catch (e) { result = msg.content; }
                 appendToolCall(msg.name, 'done', input, result);
+            } else if (msg.role === 'pending') {
+                appendAsyncTask(msg);
             }
         });
         scrollToBottom();
@@ -1736,6 +1737,44 @@ $(function () {
         }
     }
 
+    function appendAsyncTask(msg) {
+        var status  = msg.async_status || 'pending';
+        var iconMap = {
+            'pending': 'fa-spinner fa-spin',
+            'running': 'fa-spinner fa-spin',
+            'done':    'fa-check text-success',
+            'error':   'fa-times text-danger'
+        };
+        var icon    = iconMap[status] || 'fa-spinner fa-spin';
+        var label   = msg.display_text || 'Async task';
+
+        var $summary = $('<summary class="alfred-tool-call-header">')
+            .append($('<i>').addClass('fas ' + icon))
+            .append($('<code>').text(label));
+        var $details = $('<details class="alfred-tool-details">').append($summary);
+
+        var hasResult   = msg.result   !== undefined && msg.result   !== null;
+        var hasErrorMsg = msg.error_msg !== undefined && msg.error_msg !== null;
+
+        if (!hasResult && !hasErrorMsg) {
+            $details.addClass('alfred-tool-no-content');
+        }
+        if (hasResult) {
+            var rstr = typeof msg.result === 'string' ? msg.result : JSON.stringify(msg.result, null, 2);
+            $details.append($('<div class="alfred-tool-section">')
+                .append($('<span class="alfred-tool-label">').text('Result'))
+                .append($('<pre class="alfred-tool-pre">').text(rstr)));
+        }
+        if (hasErrorMsg) {
+            $details.append($('<div class="alfred-tool-section">')
+                .append($('<span class="alfred-tool-label">').text('Error'))
+                .append($('<pre class="alfred-tool-pre">').text(msg.error_msg)));
+        }
+
+        $('#alfred-messages').append($('<div class="alfred-tool-call">').append($details));
+        scrollToBottom();
+    }
+
     function showTyping() {
         if ($('#alfred-typing-indicator').length) return;
         $('#alfred-messages').append(
@@ -1816,7 +1855,15 @@ $(function () {
             dataType: 'json',
             success:  function (resp) {
                 if (resp.state !== 'ok' || !resp.result) return;
-                if (resp.result.length > knownMsgCount) { renderHistory(resp.result); loadSessions(); }
+                var hasActivePending = resp.result.some(function (m) {
+                    return m.role === 'pending'
+                        && m.async_status !== 'done'
+                        && m.async_status !== 'error';
+                });
+                if (resp.result.length > knownMsgCount || hasActivePending) {
+                    renderHistory(resp.result);
+                    loadSessions();
+                }
             }
         });
     }, 10000);

--- a/core/class/alfred.class.php
+++ b/core/class/alfred.class.php
@@ -63,7 +63,7 @@ class alfred extends eqLogic {
     public static function cron() {
         // Process any scheduled wakeups whose run_at has been reached (cron strategy only;
         // background-strategy schedules run in their own spawned process).
-        require_once __DIR__ . '/alfredScheduler.class.php';
+        require_once __DIR__ . '/alfredAsyncTask.class.php';
         require_once __DIR__ . '/alfredLLM.class.php';
         require_once __DIR__ . '/alfredMCP.class.php';
         require_once __DIR__ . '/alfredMCPRegistry.class.php';
@@ -71,9 +71,9 @@ class alfred extends eqLogic {
         require_once __DIR__ . '/alfredMemory.class.php';
         require_once __DIR__ . '/alfredAgent.class.php';
         try {
-            alfredScheduler::processPending();
+            alfredAsyncTask::processPending();
         } catch (Exception $e) {
-            log::add('alfred_cron', 'error', 'cron: alfredScheduler failed — ' . $e->getMessage());
+            log::add('alfred_cron', 'error', 'cron: alfredAsyncTask failed — ' . $e->getMessage());
         }
     }
 

--- a/core/class/alfredAgent.class.php
+++ b/core/class/alfredAgent.class.php
@@ -234,6 +234,58 @@ class alfredAgent
         return (new alfredAgent(null, null, null, $userLogin, $userProfil))->run($sessionId, '');
     }
 
+    /**
+     * Inject an async tool error into a session and run a continuation LLM turn.
+     *
+     * Symmetric to resumeWithAsyncToolResult() — use when a background tool failed
+     * so the LLM can inform the user naturally.
+     *
+     * @api Stable public contract — callable from third-party plugins.
+     *
+     * @param string  $sessionId    The Alfred session to resume
+     * @param string  $toolName     Full tool name as registered in Alfred
+     * @param string  $errorMessage Human-readable error description
+     * @param ?string $userLogin    Resolved from session if null
+     * @param ?string $userProfil   Resolved from user table if null
+     * @return string               The assistant's final text response
+     */
+    public static function resumeWithAsyncToolError(
+        string  $sessionId,
+        string  $toolName,
+        string  $errorMessage,
+        ?string $userLogin  = null,
+        ?string $userProfil = null
+    ): string {
+        if ($userLogin === null) {
+            $userLogin = alfredConversation::getUserLogin($sessionId);
+        }
+        if ($userProfil === null && $userLogin !== null) {
+            $userProfil = 'user';
+            try {
+                $u = user::byLogin($userLogin);
+                if ($u && $u->getProfils() === 'admin') {
+                    $userProfil = 'admin';
+                }
+            } catch (Exception $ignored) {}
+        }
+
+        $toolCallId = bin2hex(random_bytes(8));
+
+        alfredConversation::saveAssistantResponse($sessionId, [
+            'text'        => '',
+            'tool_calls'  => [['id' => $toolCallId, 'name' => $toolName, 'input' => []]],
+            'stop_reason' => 'tool_use',
+            'usage'       => [],
+        ]);
+
+        alfredConversation::saveToolResult($sessionId, $toolCallId, $toolName, [
+            'error'   => true,
+            'message' => $errorMessage,
+        ]);
+
+        return (new alfredAgent(null, null, null, $userLogin, $userProfil))->run($sessionId, '');
+    }
+
     private static function extensionForMime(string $mimeType): string
     {
         $map = [
@@ -614,7 +666,6 @@ class alfredAgent
 
     /**
      * Handle a call to the synthetic alfred_schedule tool.
-     * Delegates to alfredScheduler and returns a confirmation string.
      */
     private function handleScheduleTool(string $sessionId, array $input): array
     {
@@ -625,7 +676,7 @@ class alfredAgent
             return ['error' => 'delay_seconds must be positive and instruction must not be empty.'];
         }
 
-        return alfredScheduler::schedule($sessionId, $delaySeconds, $instruction);
+        return alfredAsyncTask::schedule($sessionId, $delaySeconds, $instruction);
     }
 
     // -------------------------------------------------------------------------

--- a/core/class/alfredAgent.class.php
+++ b/core/class/alfredAgent.class.php
@@ -622,6 +622,13 @@ class alfredAgent
                     'duration_ms' => (int)round((microtime(true) - $tTool) * 1000),
                 ];
 
+                // Strip internal async task marker before it reaches the LLM or the DB
+                $asyncTaskId = null;
+                if (is_array($result) && isset($result['_async_task_id'])) {
+                    $asyncTaskId = (int) $result['_async_task_id'];
+                    unset($result['_async_task_id']);
+                }
+
                 $resultStr = is_array($result)
                     ? json_encode($result, JSON_UNESCAPED_UNICODE)
                     : (string)$result;
@@ -632,6 +639,11 @@ class alfredAgent
                 $tDb = microtime(true);
                 alfredConversation::saveToolResult($sessionId, $tc['id'], $tc['name'], $result);
                 $timing['db_writes'] += (int)round((microtime(true) - $tDb) * 1000);
+
+                // Create the pending UI message AFTER the tool result so it appears last in the conversation
+                if ($asyncTaskId !== null) {
+                    alfredAsyncTask::linkMessage($asyncTaskId, $sessionId);
+                }
 
                 $messages[] = [
                     'role'        => 'tool',

--- a/core/class/alfredAgent.class.php
+++ b/core/class/alfredAgent.class.php
@@ -643,6 +643,12 @@ class alfredAgent
                 // Create the pending UI message AFTER the tool result so it appears last in the conversation
                 if ($asyncTaskId !== null) {
                     alfredAsyncTask::linkMessage($asyncTaskId, $sessionId);
+                    $task = alfredAsyncTask::getTask($asyncTaskId);
+                    $this->emit('async_task', [
+                        'task_id'      => $asyncTaskId,
+                        'display_text' => $task['display_text'] ?? '',
+                        'async_status' => 'pending',
+                    ]);
                 }
 
                 $messages[] = [

--- a/core/class/alfredAsyncTask.class.php
+++ b/core/class/alfredAsyncTask.class.php
@@ -1,0 +1,251 @@
+<?php
+
+/**
+ * Unified async task management for Alfred.
+ *
+ * Handles any deferred or background operation that needs a pending UI indicator
+ * while it executes, then resolves (success/error) and optionally resumes the LLM.
+ *
+ * Two strategies for schedule-type tasks:
+ *   background  delay < 15 min  — spawns a background PHP process
+ *   cron        delay >= 15 min — picked up by alfred::cron() at run_at time
+ *
+ * === Public API for third-party plugins ===
+ *
+ * schedule() is a stable public contract callable from outside JeedomAlfred.
+ * Minimal bootstrap:
+ *
+ *   require_once '/var/www/html/core/php/core.inc.php';
+ *   require_once '/var/www/html/plugins/alfred/core/class/alfredAsyncTask.class.php';
+ *   alfredAsyncTask::schedule($sessionId, $delaySeconds, $instruction);
+ */
+class alfredAsyncTask
+{
+    const BACKGROUND_THRESHOLD = 900; // 15 minutes
+
+    // -------------------------------------------------------------------------
+    // Public API — schedule
+    // -------------------------------------------------------------------------
+
+    /**
+     * Schedule a deferred re-invocation of the agent.
+     *
+     * @api Stable public contract — callable from third-party plugins.
+     *
+     * @param string $sessionId
+     * @param int    $delaySeconds
+     * @param string $instruction   What to ask the agent when it wakes up
+     * @return array{status: string, strategy: string, run_at: string, message: string}
+     */
+    public static function schedule(string $sessionId, int $delaySeconds, string $instruction): array
+    {
+        $runAt    = (new DateTime())->modify("+{$delaySeconds} seconds");
+        $strategy = $delaySeconds < self::BACKGROUND_THRESHOLD ? 'background' : 'cron';
+
+        $displayText = self::humanDelay($delaySeconds) . " : '{$instruction}'";
+        $payload     = [
+            'instruction' => $instruction,
+            'run_at'      => $runAt->format('Y-m-d H:i:s'),
+            'strategy'    => $strategy,
+        ];
+
+        $taskId = self::create($sessionId, 'schedule', $displayText, $payload);
+
+        if ($strategy === 'background') {
+            self::spawnBackground($taskId, $delaySeconds);
+        }
+
+        return [
+            'status'   => 'scheduled',
+            'strategy' => $strategy,
+            'run_at'   => $runAt->format('Y-m-d H:i:s'),
+            'message'  => "Scheduled in " . self::humanDelay($delaySeconds) . ": '{$instruction}'",
+        ];
+    }
+
+    // -------------------------------------------------------------------------
+    // Generic task creation (Phase 2 entry point for external plugins)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Create an async task and its linked pending UI message.
+     * Returns the new task ID.
+     */
+    public static function create(string $sessionId, string $type, string $displayText, array $payload = []): int
+    {
+        DB::Prepare(
+            'INSERT INTO alfred_async_task (session_id, type, display_text, payload)
+             VALUES (:session_id, :type, :display_text, :payload)',
+            [
+                ':session_id'   => $sessionId,
+                ':type'         => $type,
+                ':display_text' => $displayText,
+                ':payload'      => json_encode($payload, JSON_UNESCAPED_UNICODE),
+            ],
+            DB::FETCH_TYPE_ROW
+        );
+        $taskId = (int) DB::getLastInsertId();
+
+        $messageId = alfredConversation::createPendingMessage($sessionId, $displayText, $taskId);
+
+        DB::Prepare(
+            'UPDATE alfred_async_task SET message_id = :message_id WHERE id = :id',
+            [':message_id' => $messageId, ':id' => $taskId],
+            DB::FETCH_TYPE_ROW
+        );
+
+        return $taskId;
+    }
+
+    // -------------------------------------------------------------------------
+    // Status transitions
+    // -------------------------------------------------------------------------
+
+    public static function markRunning(int $taskId): void
+    {
+        DB::Prepare(
+            'UPDATE alfred_async_task SET status = \'running\', updated_at = NOW() WHERE id = :id',
+            [':id' => $taskId],
+            DB::FETCH_TYPE_ROW
+        );
+        $task = self::getTask($taskId);
+        if ($task && $task['message_id']) {
+            alfredConversation::updatePendingMessage((int) $task['message_id'], 'running');
+        }
+    }
+
+    public static function resolve(int $taskId, array $result = []): void
+    {
+        DB::Prepare(
+            'UPDATE alfred_async_task SET status = \'done\', result = :result, updated_at = NOW() WHERE id = :id',
+            [':result' => json_encode($result, JSON_UNESCAPED_UNICODE), ':id' => $taskId],
+            DB::FETCH_TYPE_ROW
+        );
+        $task = self::getTask($taskId);
+        if ($task && $task['message_id']) {
+            alfredConversation::updatePendingMessage((int) $task['message_id'], 'done', ['result' => $result]);
+        }
+    }
+
+    public static function fail(int $taskId, string $errorMsg): void
+    {
+        DB::Prepare(
+            'UPDATE alfred_async_task SET status = \'error\', error_msg = :msg, updated_at = NOW() WHERE id = :id',
+            [':msg' => $errorMsg, ':id' => $taskId],
+            DB::FETCH_TYPE_ROW
+        );
+        $task = self::getTask($taskId);
+        if ($task && $task['message_id']) {
+            alfredConversation::updatePendingMessage((int) $task['message_id'], 'error', ['error_msg' => $errorMsg]);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Cron processing (called from alfred::cron every minute)
+    // -------------------------------------------------------------------------
+
+    public static function processPending(): void
+    {
+        $rows = DB::Prepare(
+            "SELECT * FROM alfred_async_task
+             WHERE type = 'schedule' AND status = 'pending'
+               AND JSON_UNQUOTE(JSON_EXTRACT(payload, '$.strategy')) = 'cron'
+               AND JSON_UNQUOTE(JSON_EXTRACT(payload, '$.run_at')) <= NOW()",
+            [],
+            DB::FETCH_TYPE_ALL
+        ) ?: [];
+
+        foreach ($rows as $row) {
+            self::executeSchedule($row);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Task query
+    // -------------------------------------------------------------------------
+
+    public static function getTask(int $taskId): ?array
+    {
+        $row = DB::Prepare(
+            'SELECT * FROM alfred_async_task WHERE id = :id LIMIT 1',
+            [':id' => $taskId],
+            DB::FETCH_TYPE_ROW
+        );
+        return $row ?: null;
+    }
+
+    // -------------------------------------------------------------------------
+    // Internal
+    // -------------------------------------------------------------------------
+
+    private static function executeSchedule(array $row): void
+    {
+        $taskId      = (int) $row['id'];
+        $payload     = json_decode($row['payload'] ?? '{}', true);
+        $instruction = $payload['instruction'] ?? '';
+
+        log::add('alfred_cron', 'info', "=== async task #{$taskId} starting: {$instruction} ===");
+        self::markRunning($taskId);
+
+        try {
+            list($userLogin, $userProfil) = self::resolveUser($row['session_id']);
+            $agent = new alfredAgent(null, null, null, $userLogin, $userProfil);
+            $agent->run($row['session_id'], '[SCHEDULED] ' . $instruction);
+            self::resolve($taskId);
+            log::add('alfred_cron', 'info', "=== async task #{$taskId} done ===");
+        } catch (Exception $e) {
+            self::fail($taskId, $e->getMessage());
+            log::add('alfred_cron', 'error', "async task #{$taskId} failed: " . $e->getMessage());
+        }
+    }
+
+    private static function spawnBackground(int $taskId, int $delaySeconds): void
+    {
+        $php = PHP_BINARY !== '' ? PHP_BINARY : trim((string) shell_exec('which php 2>/dev/null'));
+        if ($php === '') {
+            log::add('alfred_cron', 'error', "task #{$taskId}: cannot find PHP binary, spawn aborted");
+            return;
+        }
+        $script     = dirname(__DIR__, 2) . '/api/wakeup.php';
+        $jeedomRoot = dirname(__DIR__, 4);
+        $logDir     = is_dir($jeedomRoot . '/log') ? $jeedomRoot . '/log' : sys_get_temp_dir();
+        $logFile    = $logDir . '/alfred_cron';
+
+        $cmd = escapeshellarg($php)
+             . ' ' . escapeshellarg($script)
+             . ' --task_id=' . $taskId
+             . ' --delay=' . $delaySeconds;
+
+        exec('nohup ' . $cmd . ' >> ' . escapeshellarg($logFile) . ' 2>&1 &');
+        log::add('alfred_cron', 'info', "task #{$taskId} spawned (php={$php})");
+    }
+
+    private static function resolveUser(string $sessionId): array
+    {
+        $userLogin = alfredConversation::getUserLogin($sessionId);
+        if ($userLogin === null) {
+            return [null, null];
+        }
+        $userProfil = 'user';
+        try {
+            $u = user::byLogin($userLogin);
+            if ($u && $u->getProfils() === 'admin') {
+                $userProfil = 'admin';
+            }
+        } catch (Exception $ignored) {}
+        return [$userLogin, $userProfil];
+    }
+
+    private static function humanDelay(int $delaySeconds): string
+    {
+        $h = (int) ($delaySeconds / 3600);
+        $m = (int) (($delaySeconds % 3600) / 60);
+        $s = $delaySeconds % 60;
+
+        $parts = [];
+        if ($h > 0) $parts[] = "{$h}h";
+        if ($m > 0) $parts[] = "{$m}min";
+        if ($s > 0) $parts[] = "{$s}s";
+        return implode(' ', $parts) ?: '0s';
+    }
+}

--- a/core/class/alfredAsyncTask.class.php
+++ b/core/class/alfredAsyncTask.class.php
@@ -56,10 +56,11 @@ class alfredAsyncTask
         }
 
         return [
-            'status'   => 'scheduled',
-            'strategy' => $strategy,
-            'run_at'   => $runAt->format('Y-m-d H:i:s'),
-            'message'  => "Scheduled in " . self::humanDelay($delaySeconds) . ": '{$instruction}'",
+            'status'        => 'scheduled',
+            'strategy'      => $strategy,
+            'run_at'        => $runAt->format('Y-m-d H:i:s'),
+            'message'       => "Scheduled in " . self::humanDelay($delaySeconds) . ": '{$instruction}'",
+            '_async_task_id' => $taskId, // consumed and stripped by alfredAgent before LLM sees it
         ];
     }
 
@@ -70,6 +71,13 @@ class alfredAsyncTask
     /**
      * Create an async task and its linked pending UI message.
      * Returns the new task ID.
+     */
+    /**
+     * Create an async task record.
+     *
+     * The linked pending UI message is NOT created here — the caller is responsible
+     * for calling linkMessage() after the tool result is saved to alfred_message,
+     * so that the pending message appears after the tool result in the conversation.
      */
     public static function create(string $sessionId, string $type, string $displayText, array $payload = []): int
     {
@@ -84,17 +92,26 @@ class alfredAsyncTask
             ],
             DB::FETCH_TYPE_ROW
         );
-        $taskId = (int) DB::getLastInsertId();
+        return (int) DB::getLastInsertId();
+    }
 
-        $messageId = alfredConversation::createPendingMessage($sessionId, $displayText, $taskId);
-
+    /**
+     * Create the pending UI message for a task and store the link.
+     * Must be called AFTER the tool result message is saved in alfred_message.
+     */
+    public static function linkMessage(int $taskId, string $sessionId): void
+    {
+        $task      = self::getTask($taskId);
+        $messageId = alfredConversation::createPendingMessage(
+            $sessionId,
+            $task['display_text'] ?? '',
+            $taskId
+        );
         DB::Prepare(
             'UPDATE alfred_async_task SET message_id = :message_id WHERE id = :id',
             [':message_id' => $messageId, ':id' => $taskId],
             DB::FETCH_TYPE_ROW
         );
-
-        return $taskId;
     }
 
     // -------------------------------------------------------------------------

--- a/core/class/alfredConversation.class.php
+++ b/core/class/alfredConversation.class.php
@@ -131,8 +131,44 @@ class alfredConversation
     }
 
     /**
+     * Create a pending UI message linked to an async task. Returns the new message ID.
+     */
+    public static function createPendingMessage(string $sessionId, string $displayText, int $taskId): int
+    {
+        return self::addMessage($sessionId, 'pending', $displayText, [
+            'task_id'      => $taskId,
+            'async_status' => 'pending',
+        ]);
+    }
+
+    /**
+     * Update the async_status (and optional result/error_msg) of a pending message.
+     */
+    public static function updatePendingMessage(int $messageId, string $status, array $data = []): void
+    {
+        $row = DB::Prepare(
+            'SELECT metadata FROM alfred_message WHERE id = :id LIMIT 1',
+            [':id' => $messageId],
+            DB::FETCH_TYPE_ROW
+        );
+        if (!$row) {
+            return;
+        }
+        $meta                 = $row['metadata'] ? json_decode($row['metadata'], true) : [];
+        $meta['async_status'] = $status;
+        if (array_key_exists('result', $data))    $meta['result']    = $data['result'];
+        if (array_key_exists('error_msg', $data)) $meta['error_msg'] = $data['error_msg'];
+
+        DB::Prepare(
+            'UPDATE alfred_message SET metadata = :metadata WHERE id = :id',
+            [':metadata' => json_encode($meta, JSON_UNESCAPED_UNICODE), ':id' => $messageId],
+            DB::FETCH_TYPE_ROW
+        );
+    }
+
+    /**
      * Load messages for a session as internal Alfred format (for LLM context).
-     * Error messages are excluded — they are display-only and must not pollute the LLM context.
+     * Error and pending messages are excluded — they are display-only.
      */
     public static function getMessages(string $sessionId): array
     {
@@ -148,8 +184,9 @@ class alfredConversation
             $meta    = $row['metadata'] ? json_decode($row['metadata'], true) : [];
             $content = $row['content'];
 
-            // Skip error messages — they are display-only
+            // Skip display-only messages
             if (!empty($meta['error'])) continue;
+            if ($row['role'] === 'pending') continue;
 
             $msg = ['role' => $row['role'], 'content' => $content];
 
@@ -203,6 +240,13 @@ class alfredConversation
             if ($row['role'] === 'tool') {
                 $msg['tool_call_id'] = $meta['tool_call_id'] ?? '';
                 $msg['name']         = $meta['name'] ?? '';
+            }
+            if ($row['role'] === 'pending') {
+                $msg['display_text'] = $content;
+                $msg['async_status'] = $meta['async_status'] ?? 'pending';
+                $msg['task_id']      = $meta['task_id'] ?? null;
+                if (isset($meta['result']))    $msg['result']    = $meta['result'];
+                if (isset($meta['error_msg'])) $msg['error_msg'] = $meta['error_msg'];
             }
 
             $out[] = $msg;

--- a/core/class/alfredLLMMistralAdapter.class.php
+++ b/core/class/alfredLLMMistralAdapter.class.php
@@ -226,9 +226,18 @@ class alfredLLMMistralAdapter extends alfredLLMAdapter
 
     private function toMistralMessages(array $messages): array
     {
-        $out = [];
+        $out      = [];
+        $lastRole = null;
         foreach ($messages as $msg) {
             $role = $msg['role'];
+
+            // Mistral requires strict user/assistant alternation. Two consecutive assistant
+            // messages occur when resumeWithAsyncToolResult() injects a synthetic tool-call
+            // turn after a session that ended with a normal text response. Insert a virtual
+            // user separator so the conversation stays valid.
+            if ($role === 'assistant' && $lastRole === 'assistant') {
+                $out[] = ['role' => 'user', 'content' => ''];
+            }
 
             if ($role === 'user') {
                 $out[] = ['role' => 'user', 'content' => $msg['content']];
@@ -257,6 +266,8 @@ class alfredLLMMistralAdapter extends alfredLLMAdapter
                     'name'         => $msg['name'] ?? '',
                 ];
             }
+
+            $lastRole = $role;
         }
         return $out;
     }

--- a/core/class/alfredMCP.class.php
+++ b/core/class/alfredMCP.class.php
@@ -11,11 +11,13 @@
  */
 class alfredMCP
 {
-    private string $url;
-    private string $authHeader;
-    private string $authValue;
-    private int    $timeout;
-    private ?array $cachedTools = null;
+    private string  $url;
+    private string  $authHeader;
+    private string  $authValue;
+    private int     $timeout;
+    private ?array  $cachedTools   = null;
+    private bool    $initialized   = false;
+    private ?string $mcpSessionId  = null;
 
     public function __construct(
         string $url        = '',
@@ -43,6 +45,7 @@ class alfredMCP
             return $this->cachedTools;
         }
 
+        $this->ensureInitialized();
         $response = $this->send('tools/list', new stdClass());
         $tools = $response['tools'] ?? [];
 
@@ -63,6 +66,7 @@ class alfredMCP
      */
     public function callTool(string $name, array $arguments, ?string $sessionId = null)
     {
+        $this->ensureInitialized();
         $response = $this->send('tools/call', [
             'name'      => $name,
             'arguments' => $arguments,
@@ -85,10 +89,110 @@ class alfredMCP
     // JSON-RPC transport
     // -------------------------------------------------------------------------
 
+    /**
+     * MCP Streamable HTTP handshake: initialize → capture Mcp-Session-Id → notifications/initialized.
+     * Servers that don't use sessions ignore the initialize or return no session header — no impact.
+     */
+    private function ensureInitialized(): void
+    {
+        if ($this->initialized) {
+            return;
+        }
+        $this->initialized = true;
+
+        try {
+            $responseHeaders = [];
+            $this->sendRaw(
+                json_encode([
+                    'jsonrpc' => '2.0',
+                    'id'      => 0,
+                    'method'  => 'initialize',
+                    'params'  => [
+                        'protocolVersion' => '2024-11-05',
+                        'capabilities'    => new stdClass(),
+                        'clientInfo'      => ['name' => 'alfred', 'version' => '1.0'],
+                    ],
+                ]),
+                $this->buildHeaders(),
+                $responseHeaders
+            );
+
+            foreach ($responseHeaders as $header) {
+                if (stripos($header, 'Mcp-Session-Id:') === 0) {
+                    $this->mcpSessionId = trim(substr($header, strlen('Mcp-Session-Id:')));
+                    break;
+                }
+            }
+
+            $notifHeaders = $this->buildHeaders();
+            if ($this->mcpSessionId !== null) {
+                $notifHeaders[] = 'Mcp-Session-Id: ' . $this->mcpSessionId;
+            }
+            $this->sendRaw(
+                json_encode([
+                    'jsonrpc' => '2.0',
+                    'method'  => 'notifications/initialized',
+                    'params'  => new stdClass(),
+                ]),
+                $notifHeaders,
+                $ignored
+            );
+        } catch (Exception $e) {
+            // Server doesn't require initialization — proceed without session
+        }
+    }
+
+    private function buildHeaders(): array
+    {
+        $headers = [
+            'Content-Type: application/json',
+            'Accept: application/json, text/event-stream',
+        ];
+        if ($this->authHeader !== '' && $this->authValue !== '') {
+            $headers[] = $this->authHeader . ': ' . $this->authValue;
+        }
+        return $headers;
+    }
+
+    /** Low-level curl POST; populates $responseHeaders by reference. */
+    private function sendRaw(string $payload, array $requestHeaders, ?array &$responseHeaders): string
+    {
+        $responseHeaders = [];
+        $ch = curl_init($this->url);
+        curl_setopt_array($ch, [
+            CURLOPT_POST           => true,
+            CURLOPT_POSTFIELDS     => $payload,
+            CURLOPT_HTTPHEADER     => $requestHeaders,
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_TIMEOUT        => $this->timeout,
+            CURLOPT_SSL_VERIFYPEER => true,
+            CURLOPT_HEADERFUNCTION => function ($ch, $header) use (&$responseHeaders) {
+                $responseHeaders[] = $header;
+                return strlen($header);
+            },
+        ]);
+        $raw = curl_exec($ch);
+        $err = curl_error($ch);
+        curl_close($ch);
+
+        if ($raw === false) {
+            throw new Exception("MCP HTTP request failed [{$this->url}]: {$err}");
+        }
+        return $raw;
+    }
+
     private function send(string $method, $params, ?string $sessionId = null): array
     {
         if ($this->url === '') {
             throw new Exception('MCP server URL is not configured.');
+        }
+
+        $headers = $this->buildHeaders();
+        if ($this->mcpSessionId !== null) {
+            $headers[] = 'Mcp-Session-Id: ' . $this->mcpSessionId;
+        }
+        if ($sessionId !== null && $sessionId !== '') {
+            $headers[] = 'X-Alfred-Session-Id: ' . $sessionId;
         }
 
         $payload = json_encode([
@@ -98,35 +202,9 @@ class alfredMCP
             'params'  => $params,
         ]);
 
-        $headers = [
-            'Content-Type: application/json',
-            'Accept: application/json, text/event-stream',
-        ];
-        if ($this->authHeader !== '' && $this->authValue !== '') {
-            $headers[] = $this->authHeader . ': ' . $this->authValue;
-        }
-        if ($sessionId !== null && $sessionId !== '') {
-            $headers[] = 'X-Alfred-Session-Id: ' . $sessionId;
-        }
-
-        $ch = curl_init($this->url);
-        curl_setopt_array($ch, [
-            CURLOPT_POST           => true,
-            CURLOPT_POSTFIELDS     => $payload,
-            CURLOPT_HTTPHEADER     => $headers,
-            CURLOPT_RETURNTRANSFER => true,
-            CURLOPT_TIMEOUT        => $this->timeout,
-            CURLOPT_SSL_VERIFYPEER => true,
-        ]);
-
-        $raw  = curl_exec($ch);
-        $code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-        $err  = curl_error($ch);
-        curl_close($ch);
-
-        if ($raw === false) {
-            throw new Exception("MCP HTTP request failed [{$this->url}]: {$err}");
-        }
+        $ignored = null;
+        $raw  = $this->sendRaw($payload, $headers, $ignored);
+        $code = 0;
 
         // Strip UTF-8 BOM if present (some PHP setups emit it)
         $raw  = ltrim($raw, "\xEF\xBB\xBF");
@@ -147,7 +225,7 @@ class alfredMCP
         $data = json_decode($body, true);
         if (!is_array($data)) {
             $preview = substr($raw, 0, 1000) . (strlen($raw) > 1000 ? '...' : '');
-            throw new Exception("MCP invalid JSON response (HTTP {$code}): " . $preview);
+            throw new Exception("MCP invalid JSON response: " . $preview);
         }
         if (isset($data['error'])) {
             $msg = $data['error']['message'] ?? json_encode($data['error']);

--- a/core/class/alfredMigration.class.php
+++ b/core/class/alfredMigration.class.php
@@ -4,6 +4,7 @@ class alfredMigration
 {
     const MIGRATIONS = [
         1 => 'migration_001_baseline',
+        2 => 'migration_002_async_tasks',
     ];
 
     private static function downDir(): string
@@ -33,6 +34,7 @@ class alfredMigration
         self::ensureLogTable();
 
         $current = (int) config::byKey('schemaVersion', 'alfred', 0);
+        $target  = max(array_keys(self::MIGRATIONS));
 
         // Transition: old system had individual versions; new system squashes them into new v1
         if ($current >= 1 && $current > $target) {
@@ -42,7 +44,7 @@ class alfredMigration
         }
 
         // Reset if any required table is missing (fresh install or schema corruption)
-        $required = ['alfred_message', 'alfred_conversation', 'alfred_memory', 'alfred_schedule', 'alfred_llm_call'];
+        $required = ['alfred_message', 'alfred_conversation', 'alfred_memory', 'alfred_async_task', 'alfred_llm_call'];
         foreach ($required as $table) {
             $row = DB::Prepare(
                 "SELECT COUNT(*) as cnt FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = :tbl",
@@ -240,6 +242,99 @@ class alfredMigration
             'DROP TABLE IF EXISTS `alfred_memory`',
             'DROP TABLE IF EXISTS `alfred_message`',
             'DROP TABLE IF EXISTS `alfred_conversation`',
+        ]);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Migration 2 — Unified async task table (replaces alfred_schedule)
+    //               + 'pending' role on alfred_message
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private static function migration_002_async_tasks(): void
+    {
+        DB::Prepare(
+            'ALTER TABLE `alfred_message`
+             MODIFY COLUMN `role` ENUM(\'user\',\'assistant\',\'tool\',\'error\',\'pending\') NOT NULL',
+            [],
+            DB::FETCH_TYPE_ROW
+        );
+
+        DB::Prepare(
+            'CREATE TABLE IF NOT EXISTS `alfred_async_task` (
+                `id`           INT UNSIGNED  NOT NULL AUTO_INCREMENT,
+                `session_id`   VARCHAR(36)   NOT NULL,
+                `type`         VARCHAR(64)   NOT NULL DEFAULT \'schedule\',
+                `status`       ENUM(\'pending\',\'running\',\'done\',\'error\') NOT NULL DEFAULT \'pending\',
+                `display_text` VARCHAR(255)  DEFAULT NULL,
+                `message_id`   INT UNSIGNED  DEFAULT NULL,
+                `payload`      JSON          DEFAULT NULL,
+                `result`       LONGTEXT      DEFAULT NULL,
+                `error_msg`    TEXT          DEFAULT NULL,
+                `created_at`   DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                `updated_at`   DATETIME      DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP,
+                PRIMARY KEY (`id`),
+                KEY (`session_id`),
+                KEY (`status`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4',
+            [],
+            DB::FETCH_TYPE_ROW
+        );
+
+        // Migrate pending/running schedules — done/error are historical noise, skip them
+        DB::Prepare(
+            'INSERT INTO `alfred_async_task`
+                (session_id, type, status, payload, error_msg, created_at)
+             SELECT
+                session_id,
+                \'schedule\',
+                status,
+                JSON_OBJECT(
+                    \'instruction\', instruction,
+                    \'run_at\',      DATE_FORMAT(run_at, \'%Y-%m-%d %H:%i:%s\'),
+                    \'strategy\',    strategy
+                ),
+                error_msg,
+                created_at
+             FROM `alfred_schedule`
+             WHERE status IN (\'pending\', \'running\')',
+            [],
+            DB::FETCH_TYPE_ROW
+        );
+
+        DB::Prepare('DROP TABLE IF EXISTS `alfred_schedule`', [], DB::FETCH_TYPE_ROW);
+    }
+
+    private static function migration_002_async_tasks_down(): string
+    {
+        return implode(";\n", [
+            'DELETE FROM `alfred_message` WHERE `role` = \'pending\'',
+            'ALTER TABLE `alfred_message`
+             MODIFY COLUMN `role` ENUM(\'user\',\'assistant\',\'tool\',\'error\') NOT NULL',
+            'CREATE TABLE IF NOT EXISTS `alfred_schedule` (
+                `id`          INT UNSIGNED  NOT NULL AUTO_INCREMENT,
+                `session_id`  VARCHAR(36)   NOT NULL,
+                `instruction` TEXT          NOT NULL,
+                `run_at`      DATETIME      NOT NULL,
+                `strategy`    ENUM(\'background\',\'cron\') NOT NULL,
+                `status`      ENUM(\'pending\',\'running\',\'done\',\'error\') NOT NULL DEFAULT \'pending\',
+                `error_msg`   TEXT          DEFAULT NULL,
+                `created_at`  DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (`id`),
+                KEY (`status`, `run_at`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4',
+            'INSERT INTO `alfred_schedule`
+                (session_id, instruction, run_at, strategy, status, error_msg, created_at)
+             SELECT
+                session_id,
+                JSON_UNQUOTE(JSON_EXTRACT(payload, \'$.instruction\')),
+                JSON_UNQUOTE(JSON_EXTRACT(payload, \'$.run_at\')),
+                JSON_UNQUOTE(JSON_EXTRACT(payload, \'$.strategy\')),
+                status,
+                error_msg,
+                created_at
+             FROM `alfred_async_task`
+             WHERE type = \'schedule\'',
+            'DROP TABLE IF EXISTS `alfred_async_task`',
         ]);
     }
 }

--- a/core/class/alfredScheduler.class.php
+++ b/core/class/alfredScheduler.class.php
@@ -1,223 +1,27 @@
 <?php
 
+require_once __DIR__ . '/alfredAsyncTask.class.php';
+
 /**
- * Scheduler for deferred agent re-invocations.
+ * Backward-compatibility facade for alfredAsyncTask.
  *
- * Two strategies depending on delay:
- *   background  delay < 15 min  — spawns a background PHP process that sleeps then
- *                                  calls the agent (second-level precision)
- *   cron        delay >= 15 min — stored in DB, picked up by alfred::cron() at
- *                                  run_at time (minute-level precision, acceptable)
+ * Third-party plugins that call alfredScheduler::schedule() continue to work
+ * without modification. New code should use alfredAsyncTask directly.
  *
- * Usage (internal):
- *   alfredScheduler::schedule($sessionId, 300, 'Turn off the living room light');
- *
- * === Public API for third-party plugins ===
- *
- * schedule() is a stable public contract callable from outside JeedomAlfred.
- * Minimal bootstrap — only Jeedom core and this file are required:
- *
- *   require_once '/var/www/html/core/php/core.inc.php';
- *   require_once '/var/www/html/plugins/alfred/core/class/alfredScheduler.class.php';
- *   alfredScheduler::schedule($sessionId, $delaySeconds, $instruction);
- *
- * Availability guard:
- *   if (!class_exists('alfredScheduler')) { /* Alfred not installed or not loadable *\/ }
+ * @deprecated Use alfredAsyncTask instead.
  */
 class alfredScheduler
 {
-    /** Delays below this threshold use a background process instead of the cron table. */
-    const BACKGROUND_THRESHOLD = 900; // 15 minutes in seconds
-
-    // -------------------------------------------------------------------------
-    // Public API
-    // -------------------------------------------------------------------------
-
     /**
-     * Schedule a deferred re-invocation of the agent.
-     *
-     * @api Stable public contract — callable from third-party plugins (see class docblock).
-     *
-     * @param string $sessionId     Session to re-invoke on
-     * @param int    $delaySeconds  Delay before execution
-     * @param string $instruction   What to ask the agent when it wakes up
-     * @return array{status: string, strategy: string, run_at: string, message: string}
+     * @api Stable — delegates to alfredAsyncTask::schedule().
      */
     public static function schedule(string $sessionId, int $delaySeconds, string $instruction): array
     {
-        $runAt = (new DateTime())->modify("+{$delaySeconds} seconds");
-
-        if ($delaySeconds < self::BACKGROUND_THRESHOLD) {
-            $id = self::persist($sessionId, $instruction, $runAt, 'background');
-            self::spawnBackground($id, $delaySeconds);
-            $strategy = 'background';
-        } else {
-            self::persist($sessionId, $instruction, $runAt, 'cron');
-            $strategy = 'cron';
-        }
-
-        return [
-            'status'    => 'scheduled',
-            'strategy'  => $strategy,
-            'run_at'    => $runAt->format('Y-m-d H:i:s'),
-            'message'   => self::confirmationMessage($delaySeconds, $instruction),
-        ];
+        return alfredAsyncTask::schedule($sessionId, $delaySeconds, $instruction);
     }
 
-    /**
-     * Process all pending cron-strategy schedules whose run_at has been reached.
-     * Called by alfred::cron() every minute.
-     */
     public static function processPending(): void
     {
-        $rows = DB::Prepare(
-            'SELECT * FROM alfred_schedule
-             WHERE strategy = :strategy AND status = :status AND run_at <= NOW()',
-            [':strategy' => 'cron', ':status' => 'pending'],
-            DB::FETCH_TYPE_ALL
-        ) ?: [];
-
-        foreach ($rows as $row) {
-            self::execute($row);
-        }
-    }
-
-    // -------------------------------------------------------------------------
-    // Status helpers (called from wakeup.php and processPending)
-    // -------------------------------------------------------------------------
-
-    public static function markRunning(int $id): void
-    {
-        DB::Prepare(
-            'UPDATE alfred_schedule SET status = :status WHERE id = :id',
-            [':status' => 'running', ':id' => $id],
-            DB::FETCH_TYPE_ROW
-        );
-    }
-
-    public static function markDone(int $id): void
-    {
-        DB::Prepare(
-            'UPDATE alfred_schedule SET status = :status WHERE id = :id',
-            [':status' => 'done', ':id' => $id],
-            DB::FETCH_TYPE_ROW
-        );
-    }
-
-    public static function markError(int $id, string $message): void
-    {
-        DB::Prepare(
-            'UPDATE alfred_schedule SET status = :status, error_msg = :msg WHERE id = :id',
-            [':status' => 'error', ':msg' => $message, ':id' => $id],
-            DB::FETCH_TYPE_ROW
-        );
-    }
-
-    // -------------------------------------------------------------------------
-    // Internal helpers
-    // -------------------------------------------------------------------------
-
-    /**
-     * Persist a schedule record and return its ID.
-     */
-    private static function persist(
-        string $sessionId,
-        string $instruction,
-        DateTime $runAt,
-        string $strategy
-    ): int {
-        DB::Prepare(
-            'INSERT INTO alfred_schedule (session_id, instruction, run_at, strategy)
-             VALUES (:session_id, :instruction, :run_at, :strategy)',
-            [
-                ':session_id'  => $sessionId,
-                ':instruction' => $instruction,
-                ':run_at'      => $runAt->format('Y-m-d H:i:s'),
-                ':strategy'    => $strategy,
-            ],
-            DB::FETCH_TYPE_ROW
-        );
-        return (int)DB::getLastInsertId();
-    }
-
-    /**
-     * Spawn a background PHP process that sleeps for $delaySeconds then runs wakeup.php.
-     */
-    private static function spawnBackground(int $scheduleId, int $delaySeconds): void
-    {
-        $php = PHP_BINARY !== '' ? PHP_BINARY : trim((string)shell_exec('which php 2>/dev/null'));
-        if ($php === '') {
-            log::add('alfred_cron', 'error', "schedule #{$scheduleId}: cannot find PHP binary, background spawn aborted");
-            return;
-        }
-        // __DIR__ = core/class/  →  dirname x2 = plugin root
-        $script = dirname(__DIR__, 2) . '/api/wakeup.php';
-        // dirname x4: core/class → core → plugin root → plugins → jeedom root
-        $jeedomRoot = dirname(__DIR__, 4);
-        $logDir  = is_dir($jeedomRoot . '/log') ? $jeedomRoot . '/log' : sys_get_temp_dir();
-        $logFile = $logDir . '/alfred_cron';
-
-        $cmd = escapeshellarg($php)
-             . ' ' . escapeshellarg($script)
-             . ' --schedule_id=' . (int)$scheduleId
-             . ' --delay=' . (int)$delaySeconds;
-
-        exec('nohup ' . $cmd . ' >> ' . escapeshellarg($logFile) . ' 2>&1 &');
-        log::add('alfred_cron', 'info', "schedule #{$scheduleId} spawned (php={$php})");
-    }
-
-    /**
-     * Execute a schedule row inline (used for cron strategy).
-     */
-    private static function execute(array $row): void
-    {
-        $id = (int)$row['id'];
-        log::add('alfred_cron', 'info', "=== schedule #{$id} starting: {$row['instruction']} ===");
-        self::markRunning($id);
-        try {
-            list($userLogin, $userProfil) = self::resolveUser($row['session_id']);
-            log::add('alfred_cron', 'info', "schedule #{$id}: user={$userLogin}, session={$row['session_id']}");
-            $agent = new alfredAgent(null, null, null, $userLogin, $userProfil);
-            $agent->run($row['session_id'], '[SCHEDULED] ' . $row['instruction']);
-            self::markDone($id);
-            log::add('alfred_cron', 'info', "=== schedule #{$id} done ===");
-        } catch (Exception $e) {
-            self::markError($id, $e->getMessage());
-            log::add('alfred_cron', 'error', "schedule #{$id} failed: " . $e->getMessage());
-        }
-    }
-
-    private static function resolveUser(string $sessionId): array
-    {
-        $userLogin = alfredConversation::getUserLogin($sessionId);
-        if ($userLogin === null) {
-            return [null, null];
-        }
-        $userProfil = 'user';
-        try {
-            $u = user::byLogin($userLogin);
-            if ($u && $u->getProfils() === 'admin') {
-                $userProfil = 'admin';
-            }
-        } catch (Exception $ignored) {}
-        return [$userLogin, $userProfil];
-    }
-
-    /**
-     * Build a human-readable confirmation string for the given delay.
-     */
-    private static function confirmationMessage(int $delaySeconds, string $instruction): string
-    {
-        $h = (int)($delaySeconds / 3600);
-        $m = (int)(($delaySeconds % 3600) / 60);
-        $s = $delaySeconds % 60;
-
-        $parts = [];
-        if ($h > 0) $parts[] = "{$h}h";
-        if ($m > 0) $parts[] = "{$m}min";
-        if ($s > 0) $parts[] = "{$s}s";
-        $human = implode(' ', $parts) ?: '0s';
-
-        return "Scheduled: '{$instruction}' will be executed in {$human}.";
+        alfredAsyncTask::processPending();
     }
 }

--- a/desktop/css/alfred.css
+++ b/desktop/css/alfred.css
@@ -280,6 +280,19 @@
     border-bottom-left-radius: 2px;
 }
 
+.alfred-msg.error {
+    align-self: stretch;
+}
+
+.alfred-msg.error .alfred-msg-bubble {
+    background: #fff3cd;
+    color: #856404;
+    border: 1px solid #ffc107;
+    border-radius: 8px;
+    font-size: 0.9em;
+    width: 100%;
+}
+
 /* Per-message TTS action bar */
 .alfred-msg.assistant {
     align-items: flex-start;

--- a/desktop/js/alfred.js
+++ b/desktop/js/alfred.js
@@ -197,6 +197,7 @@ $(function () {
 
     function renderHistory(messages) {
         knownMsgCount = messages.length;
+        _toolCallMap  = {};
         $('#alfred-messages').empty();
         var toolInputMap = {};
         messages.forEach(function (msg) {
@@ -211,7 +212,7 @@ $(function () {
                 }
             } else if (msg.role === 'user') {
                 if (msg.content.indexOf('[SCHEDULED]') === 0) {
-                    appendScheduledBubble(msg.content.replace('[SCHEDULED]', '').trim());
+                    // skip — shown via pending task bubble
                 } else {
                     appendBubble('user', msg.content);
                 }
@@ -220,6 +221,8 @@ $(function () {
                 var result;
                 try { result = JSON.parse(msg.content); } catch (e) { result = msg.content; }
                 appendToolCall(msg.name, 'done', input, result);
+            } else if (msg.role === 'pending') {
+                appendAsyncTask(msg);
             }
         });
         scrollToBottom();
@@ -596,6 +599,11 @@ $(function () {
             updateToolCall(d.name, 'done', d.result);
         });
 
+        source.addEventListener('async_task', function (e) {
+            var d = JSON.parse(e.data);
+            appendAsyncTask({ display_text: d.display_text, async_status: d.async_status, task_id: d.task_id });
+        });
+
         source.addEventListener('debug', function (e) {
             if (!alfred_config.isAdmin) return;
             var d = JSON.parse(e.data);
@@ -753,7 +761,7 @@ $(function () {
         if (hasResult) {
             var resultStr = typeof result === 'string' ? result : JSON.stringify(result, null, 2);
             $details.append(
-                $('<div class="alfred-tool-section">')
+                $('<div class="alfred-tool-section alfred-tool-result-section">')
                     .append($('<span class="alfred-tool-label">').text('Résultat'))
                     .append($('<pre class="alfred-tool-pre">').text(resultStr))
             );
@@ -772,15 +780,42 @@ $(function () {
         $el.find('i').attr('class', 'fas ' + icon);
 
         if (result !== undefined && result !== null) {
-            var resultStr = typeof result === 'string' ? result : JSON.stringify(result, null, 2);
             var $details = $el.find('.alfred-tool-details');
+            // Guard: only append result section if none exists yet
+            if ($details.find('.alfred-tool-result-section').length > 0) return;
+            var resultStr = typeof result === 'string' ? result : JSON.stringify(result, null, 2);
             $details.removeClass('alfred-tool-no-content');
             $details.append(
-                $('<div class="alfred-tool-section">')
+                $('<div class="alfred-tool-section alfred-tool-result-section">')
                     .append($('<span class="alfred-tool-label">').text('Résultat'))
                     .append($('<pre class="alfred-tool-pre">').text(resultStr))
             );
         }
+    }
+
+    function appendAsyncTask(msg) {
+        var status  = msg.async_status || 'pending';
+        var iconMap = { pending: 'fa-spinner fa-spin', running: 'fa-spinner fa-spin', done: 'fa-check text-success', error: 'fa-times text-danger' };
+        var $summary = $('<summary class="alfred-tool-call-header">')
+            .append($('<i>').addClass('fas ' + (iconMap[status] || 'fa-spinner fa-spin')))
+            .append($('<code>').text(msg.display_text || 'Tâche async'));
+        var $details = $('<details class="alfred-tool-details">').append($summary);
+        var hasResult = msg.result !== undefined && msg.result !== null;
+        var hasError  = msg.error_msg !== undefined && msg.error_msg !== null;
+        if (!hasResult && !hasError) $details.addClass('alfred-tool-no-content');
+        if (hasResult) {
+            var rstr = typeof msg.result === 'string' ? msg.result : JSON.stringify(msg.result, null, 2);
+            $details.append($('<div class="alfred-tool-section">')
+                .append($('<span class="alfred-tool-label">').text('Résultat'))
+                .append($('<pre class="alfred-tool-pre">').text(rstr)));
+        }
+        if (hasError) {
+            $details.append($('<div class="alfred-tool-section">')
+                .append($('<span class="alfred-tool-label">').text('Erreur'))
+                .append($('<pre class="alfred-tool-pre">').text(msg.error_msg)));
+        }
+        $('#alfred-messages').append($('<div class="alfred-tool-call">').append($details));
+        scrollToBottom();
     }
 
     function showTyping() {
@@ -864,6 +899,30 @@ $(function () {
             return v.toString(16);
         });
     }
+
+    // =========================================================================
+    // Background poll — picks up async task updates
+    // =========================================================================
+
+    setInterval(function () {
+        if (isStreaming || !currentSessionId) return;
+        $.ajax({
+            type: 'POST',
+            url: 'plugins/alfred/core/ajax/alfred.ajax.php',
+            data: { action: 'getMessages', session_id: currentSessionId },
+            dataType: 'json',
+            success: function (resp) {
+                if (resp.state !== 'ok' || !resp.result) return;
+                var hasActivePending = resp.result.some(function (m) {
+                    return m.role === 'pending' && m.async_status !== 'done' && m.async_status !== 'error';
+                });
+                if (resp.result.length > knownMsgCount || hasActivePending) {
+                    renderHistory(resp.result);
+                    loadSessions();
+                }
+            }
+        });
+    }, 5000);
 
     // =========================================================================
     // Boot

--- a/desktop/js/alfred.js
+++ b/desktop/js/alfred.js
@@ -223,6 +223,8 @@ $(function () {
                 appendToolCall(msg.name, 'done', input, result);
             } else if (msg.role === 'pending') {
                 appendAsyncTask(msg);
+            } else if (msg.role === 'error') {
+                appendBubble('error', '⚠️ ' + msg.content);
             }
         });
         scrollToBottom();

--- a/docs/async.md
+++ b/docs/async.md
@@ -1,0 +1,227 @@
+# Async tool calls — guide pour les plugins externes
+
+Ce document explique comment implémenter un outil asynchrone dans un plugin Jeedom qui s'intègre à Alfred. Un outil async est un outil dont le traitement est long (scan, upload, conversion…) et s'exécute en arrière-plan pendant qu'Alfred continue à répondre à l'utilisateur.
+
+## Vue d'ensemble
+
+```
+Tool call LLM
+     │
+     ▼
+Tool handler (plugin)
+  • alfredAsyncTask::create()    → crée la tâche en DB
+  • spawn background process     → démarre le traitement
+  • return result + _async_task_id
+     │
+     ▼
+Alfred (agent loop)
+  • strip _async_task_id
+  • saveToolResult()             → "Scan en cours, résultat dans quelques instants"
+  • linkMessage()                → message pending avec spinner dans le chat
+     │
+     ▼
+LLM → répond à l'utilisateur "Je lance le scan…"
+     │
+     ▼ (background)
+Background process (plugin)
+  • alfredAsyncTask::markRunning()
+  • ... traitement ...
+  • alfredAsyncTask::resolve() ou ::fail()
+  • alfredAgent::resumeWithAsyncToolResult() ou ::resumeWithAsyncToolError()
+     │
+     ▼
+Alfred (continuation LLM turn)
+  → "Le scan est terminé, voici les résultats : …"
+```
+
+Le chat affiche un indicateur visuel (spinner → ✓ ou ✗) lié à la tâche, sans intervention supplémentaire du plugin.
+
+---
+
+## 1. Dans le handler de l'outil
+
+Le handler est appelé par Alfred quand le LLM décide d'utiliser l'outil. Il doit :
+
+1. Créer la tâche via `alfredAsyncTask::create()`
+2. Spawner un processus background
+3. Retourner un résultat contenant `_async_task_id`
+
+**Alfred strip automatiquement `_async_task_id` avant de l'envoyer au LLM et à la DB.**
+
+```php
+// core/php/myTool.php — handler d'outil appelé par Alfred via MCP ou Jeedom
+function handleMyScanTool(string $sessionId, array $params): array
+{
+    // 1. Créer la tâche async
+    $taskId = alfredAsyncTask::create(
+        $sessionId,
+        'ext_myplugin_scan',           // type libre, convention : ext_<plugin>_<action>
+        'Scan en cours…',              // texte affiché dans le spinner
+        ['file_id' => $params['file_id'], 'options' => $params['options']]  // payload libre
+    );
+
+    // 2. Spawner le processus background
+    $php    = PHP_BINARY;
+    $script = __DIR__ . '/scan_worker.php';
+    $cmd    = escapeshellarg($php) . ' ' . escapeshellarg($script) . ' --task_id=' . $taskId;
+    exec('nohup ' . $cmd . ' >> ' . sys_get_temp_dir() . '/myplugin_scan.log 2>&1 &');
+
+    // 3. Retourner le résultat (avec _async_task_id — stripped par Alfred avant le LLM)
+    return [
+        'status'         => 'processing',
+        'message'        => 'Scan lancé, le résultat arrivera dans quelques instants.',
+        '_async_task_id' => $taskId,
+    ];
+}
+```
+
+> **Pourquoi `_async_task_id` dans le résultat ?**
+> Alfred utilise ce marqueur pour créer le message pending *après* avoir sauvegardé le résultat de l'outil, garantissant l'ordre correct d'affichage dans le chat. Il est supprimé avant que le LLM et la DB ne voient quoi que ce soit.
+
+---
+
+## 2. Dans le processus background
+
+Le worker s'exécute en CLI, indépendamment du cycle de requête HTTP d'Alfred.
+
+```php
+<?php
+// core/php/scan_worker.php
+
+if (php_sapi_name() !== 'cli') { exit(1); }
+
+$opts   = getopt('', ['task_id:']);
+$taskId = (int)($opts['task_id'] ?? 0);
+if ($taskId <= 0) { exit(1); }
+
+// Bootstrap Jeedom
+require_once '/var/www/html/core/php/core.inc.php';
+
+// Charger les classes Alfred nécessaires
+require_once '/var/www/html/plugins/alfred/core/class/alfredConversation.class.php';
+require_once '/var/www/html/plugins/alfred/core/class/alfredAsyncTask.class.php';
+require_once '/var/www/html/plugins/alfred/core/class/alfredLLM.class.php';
+require_once '/var/www/html/plugins/alfred/core/class/alfredMCP.class.php';
+require_once '/var/www/html/plugins/alfred/core/class/alfredMCPRegistry.class.php';
+require_once '/var/www/html/plugins/alfred/core/class/alfredMemory.class.php';
+require_once '/var/www/html/plugins/alfred/core/class/alfredAgent.class.php';
+
+// Charger vos propres classes
+require_once __DIR__ . '/../class/myPlugin.class.php';
+
+// Récupérer la tâche
+$task = alfredAsyncTask::getTask($taskId);
+if ($task === null || $task['status'] !== 'pending') { exit(0); }
+
+$payload   = json_decode($task['payload'] ?? '{}', true);
+$sessionId = $task['session_id'];
+
+alfredAsyncTask::markRunning($taskId);
+
+try {
+    // Traitement long
+    $result = myPlugin::runScan($payload['file_id'], $payload['options']);
+
+    // Succès
+    alfredAsyncTask::resolve($taskId, $result);
+    alfredAgent::resumeWithAsyncToolResult(
+        $sessionId,
+        'ext_myplugin_scan',   // même nom que lors du tool call
+        $result
+    );
+
+} catch (Exception $e) {
+    // Échec
+    alfredAsyncTask::fail($taskId, $e->getMessage());
+    alfredAgent::resumeWithAsyncToolError(
+        $sessionId,
+        'ext_myplugin_scan',
+        $e->getMessage()
+    );
+}
+```
+
+---
+
+## 3. Référence API
+
+### `alfredAsyncTask::create()`
+
+```php
+alfredAsyncTask::create(
+    string $sessionId,
+    string $type,        // convention : 'ext_<plugin>_<action>'
+    string $displayText, // affiché dans le spinner : "Scan en cours…"
+    array  $payload = [] // données libres récupérables dans le worker via getTask()
+): int                   // task ID
+```
+
+Crée la tâche en DB (status `pending`). Ne crée pas encore le message pending — Alfred s'en charge après avoir sauvegardé le résultat de l'outil.
+
+### `alfredAsyncTask::getTask(int $taskId): ?array`
+
+Retourne la ligne complète de la tâche, ou `null` si introuvable. Champs utiles : `session_id`, `payload` (JSON), `status`, `message_id`.
+
+### `alfredAsyncTask::markRunning(int $taskId): void`
+
+Passe le statut à `running` et met à jour le spinner dans le chat.
+
+### `alfredAsyncTask::resolve(int $taskId, array $result = []): void`
+
+Passe le statut à `done`, stocke le résultat, et met à jour l'icône du chat (✓). À appeler **avant** `resumeWithAsyncToolResult()`.
+
+### `alfredAsyncTask::fail(int $taskId, string $errorMsg): void`
+
+Passe le statut à `error`, stocke le message d'erreur, et met à jour l'icône du chat (✗). À appeler **avant** `resumeWithAsyncToolError()`.
+
+### `alfredAgent::resumeWithAsyncToolResult()`
+
+```php
+alfredAgent::resumeWithAsyncToolResult(
+    string  $sessionId,
+    string  $toolName,    // nom de l'outil tel que déclaré dans Alfred
+    array   $toolResult,  // résultat à injecter dans le contexte LLM
+    ?string $userLogin  = null,  // résolu depuis la session si null
+    ?string $userProfil = null
+): string // réponse finale du LLM
+```
+
+Injecte le résultat et relance un tour LLM pour que l'agent réponde à l'utilisateur.
+
+### `alfredAgent::resumeWithAsyncToolError()`
+
+```php
+alfredAgent::resumeWithAsyncToolError(
+    string  $sessionId,
+    string  $toolName,
+    string  $errorMessage,
+    ?string $userLogin  = null,
+    ?string $userProfil = null
+): string
+```
+
+Injecte une erreur et relance un tour LLM.
+
+---
+
+## 4. Convention de nommage
+
+| Élément | Convention | Exemple |
+|---|---|---|
+| `type` dans la table | `ext_<plugin>_<action>` | `ext_jaganin_document_scan` |
+| Nom de l'outil MCP | `ext_<plugin>_<action>` | `ext_jaganin_document_scan` |
+| Script worker | `<action>_worker.php` | `scan_worker.php` |
+| Fichier log | `/log/<plugin>_<action>` | `/log/jaganin_scan` |
+
+---
+
+## 5. Garde-fou : vérification du statut avant exécution
+
+Le worker doit toujours vérifier que la tâche est encore `pending` avant de s'exécuter, pour éviter les doublons en cas de relance :
+
+```php
+$task = alfredAsyncTask::getTask($taskId);
+if ($task === null || $task['status'] !== 'pending') {
+    exit(0); // déjà exécuté ou annulé
+}
+```

--- a/docs/database.md
+++ b/docs/database.md
@@ -18,7 +18,7 @@ erDiagram
     alfred_message {
         int id PK
         varchar session_id
-        varchar role "user, assistant, tool, error"
+        varchar role "user, assistant, tool, error, pending"
         longtext content
         json metadata
         datetime created_at
@@ -50,20 +50,24 @@ erDiagram
         datetime updated_at
     }
 
-    alfred_schedule {
+    alfred_async_task {
         int id PK
         varchar session_id
-        text instruction
-        datetime run_at
-        varchar strategy "background, cron"
+        varchar type "schedule, ext_*"
         varchar status "pending, running, done, error"
+        varchar display_text
+        int message_id FK
+        json payload
+        longtext result
         text error_msg
         datetime created_at
+        datetime updated_at
     }
 
     alfred_conversation ||--o{ alfred_message : "session_id"
-    alfred_conversation ||--o{ alfred_schedule : "session_id"
+    alfred_conversation ||--o{ alfred_async_task : "session_id"
     alfred_message |o--o| alfred_llm_call : "message_id"
+    alfred_async_task |o--o| alfred_message : "message_id"
 ```
 
 > Les relations sont portées par `session_id` (VARCHAR) et non par des clés étrangères déclarées, conformément aux autres tables du schéma Jeedom.
@@ -85,16 +89,18 @@ Une ligne par session de chat. `session_id` est un UUID v4 généré côté PHP.
 
 ### `alfred_message`
 
-Un message par ligne (utilisateur, assistant, résultat d'outil, ou erreur).
+Un message par ligne (utilisateur, assistant, résultat d'outil, erreur, ou tâche async en attente).
 
 | Colonne | Type | Description |
 |---|---|---|
 | `id` | INT UNSIGNED | PK auto-incrément |
 | `session_id` | VARCHAR(36) | Référence vers `alfred_conversation.session_id` |
-| `role` | ENUM | `user`, `assistant`, `tool`, ou `error` |
+| `role` | ENUM | `user`, `assistant`, `tool`, `error`, ou `pending` |
 | `content` | LONGTEXT | Contenu Markdown ou JSON (tool results) |
-| `metadata` | JSON | Provider, model, tool calls… (structure libre) |
+| `metadata` | JSON | Provider, model, tool calls… — pour `pending` : `{task_id, async_status, result?, error_msg?}` |
 | `created_at` | DATETIME | |
+
+Les messages `pending` sont display-only (exclus du contexte LLM). Leur `metadata.async_status` suit les transitions `pending → running → done/error`.
 
 ### `alfred_llm_call`
 
@@ -130,20 +136,23 @@ Mémoire persistante entre sessions, organisée par portée.
 | `created_at` | DATETIME | |
 | `updated_at` | DATETIME | |
 
-### `alfred_schedule`
+### `alfred_async_task`
 
-Tâches différées demandées par l'utilisateur à Alfred.
+Toutes les tâches asynchrones d'Alfred — actuellement les schedules, extensible aux plugins externes (Phase 2).
 
 | Colonne | Type | Description |
 |---|---|---|
 | `id` | INT UNSIGNED | PK auto-incrément |
 | `session_id` | VARCHAR(36) | Session d'origine |
-| `instruction` | TEXT | Instruction à exécuter |
-| `run_at` | DATETIME | Date/heure d'exécution prévue |
-| `strategy` | ENUM | `background` (one-shot) ou `cron` (récurrent) |
+| `type` | VARCHAR(64) | `schedule`, `ext_<plugin>_<action>`… |
 | `status` | ENUM | `pending`, `running`, `done`, `error` |
+| `display_text` | VARCHAR(255) | Texte affiché dans le message pending UI |
+| `message_id` | INT UNSIGNED | Référence vers `alfred_message.id` (le message pending) |
+| `payload` | JSON | Données spécifiques au type — pour `schedule` : `{instruction, run_at, strategy}` |
+| `result` | LONGTEXT | JSON résultat en cas de succès |
 | `error_msg` | TEXT | Message d'erreur éventuel |
 | `created_at` | DATETIME | |
+| `updated_at` | DATETIME | Mis à jour à chaque transition de statut |
 
 ---
 
@@ -181,18 +190,19 @@ Ce répertoire est exclu de git (`var/` dans `.gitignore`) et persiste sur le Pi
    ```php
    const MIGRATIONS = [
        1 => 'migration_001_baseline',
-       2 => 'migration_002_mon_changement',  // ← nouvelle entrée
+       2 => 'migration_002_async_tasks',
+       3 => 'migration_003_mon_changement',  // ← nouvelle entrée
    ];
    ```
 
 2. Écrire les méthodes `up` et `down` **ensemble** :
    ```php
-   private static function migration_002_mon_changement(): void
+   private static function migration_003_mon_changement(): void
    {
        DB::Prepare("ALTER TABLE `alfred_message` ADD COLUMN `foo` VARCHAR(50) DEFAULT NULL", [], DB::FETCH_TYPE_ROW);
    }
 
-   private static function migration_002_mon_changement_down(): string
+   private static function migration_003_mon_changement_down(): string
    {
        return "ALTER TABLE `alfred_message` DROP COLUMN `foo`";
    }


### PR DESCRIPTION
## Summary

- Remplace `alfred_schedule` par une table générique `alfred_async_task` (type, payload JSON, message_id lié)
- Ajoute le rôle `pending` sur `alfred_message` : indicateur visuel dans le chat pendant qu'une tâche tourne (spinner → ✓ ou ✗)
- `alfredScheduler` conservé comme facade de compatibilité (2 méthodes)
- Nouveau `alfredAgent::resumeWithAsyncToolError()` — symétrique de `resumeWithAsyncToolResult()`
- Frontend : `appendAsyncTask()` calqué sur `appendToolCall`, polling adapté pour re-rendre si des tâches actives existent

## Migration

Migration 002 (automatique au déploiement) :
1. `ALTER TABLE alfred_message` : ajoute `'pending'` au ENUM `role`
2. `CREATE TABLE alfred_async_task`
3. Migre les schedules `pending`/`running` existants vers `alfred_async_task`
4. `DROP TABLE alfred_schedule`

Rollback disponible via `alfredMigration::rollbackTo(1)`.

## Test plan

- [ ] Demander à Alfred de faire quelque chose "dans 2 minutes" → message pending avec spinner visible
- [ ] Attendre l'exécution → spinner passe en ✓, réponse de l'agent apparaît
- [ ] Vérifier que les anciennes conversations sans pending ne sont pas impactées
- [ ] Vérifier que le polling re-rend bien le statut (pas besoin de recharger)
- [ ] Tester sur une install fraîche (migration 001 + 002)
- [ ] Tester sur l'install existante du Pi (migration 002 sur alfred_schedule existante)

Closes #45