### PR TITLE
feat(memory): add optional expiration date to memory entries

### DIFF
--- a/core/ajax/alfred.ajax.php
+++ b/core/ajax/alfred.ajax.php
@@ -157,16 +157,19 @@ try {
 
     if ($action === 'updateMemory') {
         if (!isConnect('admin')) throw new Exception(__('401 - Unauthorized access', __FILE__));
-        $id      = (int)init('id');
-        $label   = trim(init('label'));
-        $content = trim(init('content'));
-        $scope   = trim(init('scope'));
+        $id         = (int)init('id');
+        $label      = trim(init('label'));
+        $content    = trim(init('content'));
+        $scope      = trim(init('scope'));
+        $expiresRaw = trim(init('expires_at', ''));
         if ($id <= 0)        throw new Exception('Missing or invalid id');
         if ($label === '')   throw new Exception('Label must not be empty');
         if ($content === '') throw new Exception('Content must not be empty');
         if ($scope === '')   throw new Exception('Scope must not be empty');
+        $setExpiry = ($expiresRaw !== '__KEEP__');
+        $expiresAt = ($setExpiry && $expiresRaw !== '') ? $expiresRaw . ' 00:00:00' : null;
         require_once __DIR__ . '/../class/alfredMemory.class.php';
-        alfredMemory::adminUpdate($id, $label, $content, $scope);
+        alfredMemory::adminUpdate($id, $label, $content, $scope, $setExpiry, $expiresAt);
         ajax::success();
     }
 
@@ -181,16 +184,18 @@ try {
 
     if ($action === 'createMemory') {
         if (!isConnect('admin')) throw new Exception(__('401 - Unauthorized access', __FILE__));
-        $label   = trim(init('label'));
-        $content = trim(init('content'));
-        $scope   = trim(init('scope'));
+        $label      = trim(init('label'));
+        $content    = trim(init('content'));
+        $scope      = trim(init('scope'));
+        $expiresRaw = trim(init('expires_at', ''));
         if ($label === '')   throw new Exception('Label must not be empty');
         if ($content === '') throw new Exception('Content must not be empty');
         if ($scope === '')   throw new Exception('Scope must not be empty');
+        $expiresAt = $expiresRaw !== '' ? $expiresRaw . ' 00:00:00' : null;
         require_once __DIR__ . '/../class/alfredMemory.class.php';
-        $id  = alfredMemory::save($scope, $label, $content);
+        $id  = alfredMemory::save($scope, $label, $content, $expiresAt);
         $now = date('Y-m-d H:i:s');
-        ajax::success(['id' => $id, 'scope' => $scope, 'label' => $label, 'content' => $content, 'created_at' => $now, 'updated_at' => $now]);
+        ajax::success(['id' => $id, 'scope' => $scope, 'label' => $label, 'content' => $content, 'created_at' => $now, 'updated_at' => $now, 'expires_at' => $expiresAt]);
     }
 
     if ($action === 'deletePhone') {

--- a/core/ajax/alfred.ajax.php
+++ b/core/ajax/alfred.ajax.php
@@ -166,10 +166,12 @@ try {
         if ($label === '')   throw new Exception('Label must not be empty');
         if ($content === '') throw new Exception('Content must not be empty');
         if ($scope === '')   throw new Exception('Scope must not be empty');
-        $setExpiry = ($expiresRaw !== '__KEEP__');
-        $expiresAt = ($setExpiry && $expiresRaw !== '') ? $expiresRaw . ' 00:00:00' : null;
+        if ($expiresRaw !== '' && !preg_match('/^\d{4}-\d{2}-\d{2}$/', $expiresRaw)) {
+            throw new Exception('Invalid expires_at format, expected YYYY-MM-DD');
+        }
+        $expiresAt = $expiresRaw !== '' ? $expiresRaw . ' 00:00:00' : null;
         require_once __DIR__ . '/../class/alfredMemory.class.php';
-        alfredMemory::adminUpdate($id, $label, $content, $scope, $setExpiry, $expiresAt);
+        alfredMemory::adminUpdate($id, $label, $content, $scope, true, $expiresAt);
         ajax::success();
     }
 
@@ -191,6 +193,9 @@ try {
         if ($label === '')   throw new Exception('Label must not be empty');
         if ($content === '') throw new Exception('Content must not be empty');
         if ($scope === '')   throw new Exception('Scope must not be empty');
+        if ($expiresRaw !== '' && !preg_match('/^\d{4}-\d{2}-\d{2}$/', $expiresRaw)) {
+            throw new Exception('Invalid expires_at format, expected YYYY-MM-DD');
+        }
         $expiresAt = $expiresRaw !== '' ? $expiresRaw . ' 00:00:00' : null;
         require_once __DIR__ . '/../class/alfredMemory.class.php';
         $id  = alfredMemory::save($scope, $label, $content, $expiresAt);

--- a/core/class/alfred.class.php
+++ b/core/class/alfred.class.php
@@ -114,6 +114,11 @@ class alfred extends eqLogic {
         } catch (Exception $e) {
             log::add('alfred_cron', 'error', 'cronDaily: alfredJournal failed — ' . $e->getMessage());
         }
+        try {
+            alfredMemory::cronDaily();
+        } catch (Exception $e) {
+            log::add('alfred_cron', 'error', 'cronDaily: memory cleanup failed — ' . $e->getMessage());
+        }
     }
 
     // -------------------------------------------------------------------------

--- a/core/class/alfredAgent.class.php
+++ b/core/class/alfredAgent.class.php
@@ -356,6 +356,7 @@ class alfredAgent
                         ],
                         'expires_in_days' => [
                             'type'        => 'integer',
+                            'minimum'     => 1,
                             'description' => 'Optional. Number of days until this memory expires and is automatically deleted. Omit for a permanent memory.',
                         ],
                     ],
@@ -373,6 +374,7 @@ class alfredAgent
                         'content' => ['type' => 'string', 'description' => 'New content for this memory.'],
                         'expires_in_days' => [
                             'type'        => 'integer',
+                            'minimum'     => 0,
                             'description' => 'Optional. Set or update the expiration: positive integer = days from now, 0 = remove expiration (make permanent). Omit to keep existing expiration unchanged.',
                         ],
                     ],

--- a/core/class/alfredAgent.class.php
+++ b/core/class/alfredAgent.class.php
@@ -354,6 +354,10 @@ class alfredAgent
                             'type'        => 'string',
                             'description' => 'The fact or information to remember.',
                         ],
+                        'expires_in_days' => [
+                            'type'        => 'integer',
+                            'description' => 'Optional. Number of days until this memory expires and is automatically deleted. Omit for a permanent memory.',
+                        ],
                     ],
                     'required' => ['scope', 'label', 'content'],
                 ],
@@ -367,6 +371,10 @@ class alfredAgent
                     'properties' => [
                         'label'   => ['type' => 'string', 'description' => 'Text label of the memory to update.'],
                         'content' => ['type' => 'string', 'description' => 'New content for this memory.'],
+                        'expires_in_days' => [
+                            'type'        => 'integer',
+                            'description' => 'Optional. Set or update the expiration: positive integer = days from now, 0 = remove expiration (make permanent). Omit to keep existing expiration unchanged.',
+                        ],
                     ],
                     'required' => ['label', 'content'],
                 ],
@@ -823,6 +831,9 @@ class alfredAgent
             $block = "\n\n## Persistent memory\n";
             foreach ($memories as $m) {
                 $heading = $m['label'] !== '' ? $m['label'] : (($m['scope'] === 'global' ? 'global' : 'personal') . '-' . $m['id']);
+                if (!empty($m['expires_at'])) {
+                    $heading .= ' *(expires ' . substr($m['expires_at'], 0, 10) . ')*';
+                }
                 $block  .= "\n### {$heading}\n{$m['content']}\n";
             }
             $prompt .= $block;
@@ -873,7 +884,11 @@ class alfredAgent
                     } else {
                         $scope = 'global';
                     }
-                    alfredMemory::save($scope, $label, $content);
+                    $expiresAt = null;
+                    if (isset($input['expires_in_days']) && (int)$input['expires_in_days'] > 0) {
+                        $expiresAt = date('Y-m-d H:i:s', strtotime('+' . (int)$input['expires_in_days'] . ' days'));
+                    }
+                    alfredMemory::save($scope, $label, $content, $expiresAt);
                     return "Memory '{$label}' saved.";
 
                 case 'alfred_memory_update':
@@ -881,7 +896,17 @@ class alfredAgent
                     $content = trim((string)($input['content'] ?? ''));
                     if ($label   === '') return 'Error: label must not be empty.';
                     if ($content === '') return 'Error: content must not be empty.';
-                    alfredMemory::updateByLabel($label, $content, $allowedScopes);
+                    $setExpiry = false;
+                    $expiresAt = null;
+                    if (array_key_exists('expires_in_days', $input)) {
+                        $setExpiry = true;
+                        $days = (int)$input['expires_in_days'];
+                        if ($days > 0) {
+                            $expiresAt = date('Y-m-d H:i:s', strtotime('+' . $days . ' days'));
+                        }
+                        // $days === 0: clear expiration, $expiresAt stays null
+                    }
+                    alfredMemory::updateByLabel($label, $content, $allowedScopes, $setExpiry, $expiresAt);
                     return "Memory '{$label}' updated.";
 
                 case 'alfred_memory_forget':

--- a/core/class/alfredMemory.class.php
+++ b/core/class/alfredMemory.class.php
@@ -20,8 +20,10 @@ class alfredMemory
 
     /**
      * Update content of a memory by label. Enforces scope unless $allowedScopes is null (admin).
+     * If $setExpiry is true, expires_at is set to $expiresAt (null clears expiration).
+     * If $setExpiry is false, the existing expires_at value is preserved.
      */
-    public static function updateByLabel(string $label, string $content, ?array $allowedScopes = null): void
+    public static function updateByLabel(string $label, string $content, ?array $allowedScopes = null, bool $setExpiry = false, ?string $expiresAt = null): void
     {
         $row = self::getByLabel($label);
         if ($row === null) {
@@ -30,11 +32,19 @@ class alfredMemory
         if ($allowedScopes !== null && !in_array($row['scope'], $allowedScopes, true)) {
             throw new Exception("Memory '{$label}' access denied.");
         }
-        DB::Prepare(
-            'UPDATE alfred_memory SET content = :content, updated_at = NOW() WHERE id = :id',
-            [':content' => $content, ':id' => $row['id']],
-            DB::FETCH_TYPE_ROW
-        );
+        if ($setExpiry) {
+            DB::Prepare(
+                'UPDATE alfred_memory SET content = :content, expires_at = :expires_at, updated_at = NOW() WHERE id = :id',
+                [':content' => $content, ':expires_at' => $expiresAt, ':id' => $row['id']],
+                DB::FETCH_TYPE_ROW
+            );
+        } else {
+            DB::Prepare(
+                'UPDATE alfred_memory SET content = :content, updated_at = NOW() WHERE id = :id',
+                [':content' => $content, ':id' => $row['id']],
+                DB::FETCH_TYPE_ROW
+            );
+        }
     }
 
     /**
@@ -58,17 +68,27 @@ class alfredMemory
 
     /**
      * Admin: update content, scope and label of a memory by numeric ID.
+     * If $setExpiry is true, expires_at is set to $expiresAt (null clears expiration).
+     * If $setExpiry is false, the existing expires_at value is preserved.
      */
-    public static function adminUpdate(int $id, string $label, string $content, string $scope): void
+    public static function adminUpdate(int $id, string $label, string $content, string $scope, bool $setExpiry = false, ?string $expiresAt = null): void
     {
         if (self::getById($id) === null) {
             throw new Exception('Memory #' . $id . ' not found.');
         }
-        DB::Prepare(
-            'UPDATE alfred_memory SET label = :label, content = :content, scope = :scope, updated_at = NOW() WHERE id = :id',
-            [':label' => $label, ':content' => $content, ':scope' => $scope, ':id' => $id],
-            DB::FETCH_TYPE_ROW
-        );
+        if ($setExpiry) {
+            DB::Prepare(
+                'UPDATE alfred_memory SET label = :label, content = :content, scope = :scope, expires_at = :expires_at, updated_at = NOW() WHERE id = :id',
+                [':label' => $label, ':content' => $content, ':scope' => $scope, ':expires_at' => $expiresAt, ':id' => $id],
+                DB::FETCH_TYPE_ROW
+            );
+        } else {
+            DB::Prepare(
+                'UPDATE alfred_memory SET label = :label, content = :content, scope = :scope, updated_at = NOW() WHERE id = :id',
+                [':label' => $label, ':content' => $content, ':scope' => $scope, ':id' => $id],
+                DB::FETCH_TYPE_ROW
+            );
+        }
     }
 
     /**
@@ -95,7 +115,7 @@ class alfredMemory
     public static function loadForUser(string $login): array
     {
         return DB::Prepare(
-            'SELECT id, scope, label, content, created_at FROM alfred_memory'
+            'SELECT id, scope, label, content, created_at, expires_at FROM alfred_memory'
             . ' WHERE scope IN (:g, :u)'
             . ' AND (expires_at IS NULL OR expires_at > NOW())'
             . ' ORDER BY created_at ASC',
@@ -114,6 +134,18 @@ class alfredMemory
             [],
             DB::FETCH_TYPE_ALL
         ) ?: [];
+    }
+
+    /**
+     * Delete all expired memory rows. Called from the daily cron to keep the table lean.
+     */
+    public static function cronDaily(): void
+    {
+        DB::Prepare(
+            'DELETE FROM alfred_memory WHERE expires_at IS NOT NULL AND expires_at <= NOW()',
+            [],
+            DB::FETCH_TYPE_ROW
+        );
     }
 
     /**

--- a/core/class/alfredMigration.class.php
+++ b/core/class/alfredMigration.class.php
@@ -400,7 +400,7 @@ class alfredMigration
     }
 
     // ─────────────────────────────────────────────────────────────────────────
-    // Migration 4 — Add expires_at column to alfred_memory (for journal expiry)
+    // Migration 4 — Optional expiration date on memory entries
     // ─────────────────────────────────────────────────────────────────────────
 
     private static function migration_004_memory_expiry(): void
@@ -413,7 +413,20 @@ class alfredMigration
         );
         if (!isset($row['cnt']) || (int)$row['cnt'] === 0) {
             DB::Prepare(
-                'ALTER TABLE `alfred_memory` ADD COLUMN `expires_at` DATETIME DEFAULT NULL',
+                'ALTER TABLE `alfred_memory` ADD COLUMN `expires_at` DATETIME DEFAULT NULL AFTER `updated_at`',
+                [],
+                DB::FETCH_TYPE_ROW
+            );
+        }
+        $idxRow = DB::Prepare(
+            "SELECT COUNT(*) as cnt FROM information_schema.statistics
+             WHERE table_schema = DATABASE() AND table_name = 'alfred_memory' AND index_name = 'idx_expires_at'",
+            [],
+            DB::FETCH_TYPE_ROW
+        );
+        if (!isset($idxRow['cnt']) || (int)$idxRow['cnt'] === 0) {
+            DB::Prepare(
+                'ALTER TABLE `alfred_memory` ADD INDEX `idx_expires_at` (`expires_at`)',
                 [],
                 DB::FETCH_TYPE_ROW
             );

--- a/plugin_info/configuration.php
+++ b/plugin_info/configuration.php
@@ -355,6 +355,7 @@ $_mcpServersJson = is_array($_mcpRaw) ? (json_encode($_mcpRaw) ?: '[]') : ($_mcp
                             <th style="width:150px">{{Label}}</th>
                             <th>{{Content}}</th>
                             <th style="width:140px">{{Date}}</th>
+                            <th style="width:110px">{{Expires}}</th>
                             <th style="width:60px"></th>
                         </tr>
                     </thead>
@@ -1021,13 +1022,15 @@ function alfredMemoryRowView(m) {
     var scopeBadge = m.scope === 'global'
         ? '<span class="label label-primary">global</span>'
         : '<span class="label label-default">' + m.scope + '</span>';
-    var date  = m.created_at ? m.created_at.substring(0, 16) : '';
-    var label = m.label ? '<code>' + $('<span>').text(m.label).html() + '</code>' : '<em style="color:#aaa">—</em>';
+    var date    = m.created_at ? m.created_at.substring(0, 16) : '';
+    var expires = m.expires_at ? '<span class="label label-warning" title="{{Expires}}">' + m.expires_at.substring(0, 10) + '</span>' : '<em style="color:#aaa">—</em>';
+    var label   = m.label ? '<code>' + $('<span>').text(m.label).html() + '</code>' : '<em style="color:#aaa">—</em>';
     return '<td><small>#' + m.id + '</small></td>'
         + '<td class="alfred-mem-scope-cell">' + scopeBadge + '</td>'
         + '<td class="alfred-mem-label-cell">' + label + '</td>'
         + '<td class="alfred-mem-content-cell" style="word-break:break-word">' + $('<span>').text(m.content).html() + '</td>'
         + '<td><small>' + date + '</small></td>'
+        + '<td>' + expires + '</td>'
         + '<td style="white-space:nowrap">'
         + '<button type="button" class="btn btn-xs btn-default alfred-memory-edit" data-id="' + m.id + '" title="{{Edit}}"><i class="fas fa-pencil-alt"></i></button> '
         + '<button type="button" class="btn btn-xs btn-danger alfred-memory-delete" data-id="' + m.id + '" title="{{Delete}}"><i class="fas fa-trash"></i></button>'
@@ -1035,11 +1038,13 @@ function alfredMemoryRowView(m) {
 }
 
 function alfredMemoryRowEdit(m) {
+    var expiresVal = m.expires_at ? m.expires_at.substring(0, 10) : '';
     return '<td><small>#' + m.id + '</small></td>'
         + '<td><select class="form-control input-sm alfred-mem-scope-input" style="min-width:110px">' + alfredScopeOptions(m.scope) + '</select></td>'
         + '<td><input type="text" class="form-control input-sm alfred-mem-label-input" value="' + $('<span>').text(m.label || '').html() + '" style="font-size:12px;font-family:monospace"></td>'
         + '<td><textarea class="form-control alfred-mem-content-input" rows="2" style="font-size:12px">' + $('<span>').text(m.content).html() + '</textarea></td>'
         + '<td></td>'
+        + '<td><input type="date" class="form-control input-sm alfred-mem-expires-input" value="' + expiresVal + '" style="font-size:12px" title="{{Leave blank for no expiration}}"></td>'
         + '<td style="white-space:nowrap">'
         + '<button type="button" class="btn btn-xs btn-success alfred-memory-save" data-id="' + m.id + '" title="{{Save}}"><i class="fas fa-check"></i></button> '
         + '<button type="button" class="btn btn-xs btn-default alfred-memory-cancel" data-id="' + m.id + '" title="{{Cancel}}"><i class="fas fa-times"></i></button>'
@@ -1098,24 +1103,26 @@ $(document).on('click', '.alfred-memory-cancel', function () {
 });
 
 $(document).on('click', '.alfred-memory-save', function () {
-    var $btn     = $(this);
-    var id       = $btn.data('id');
-    var $tr      = $btn.closest('tr');
-    var label    = $tr.find('.alfred-mem-label-input').val().trim();
-    var content  = $tr.find('.alfred-mem-content-input').val().trim();
-    var scope    = $tr.find('.alfred-mem-scope-input').val();
+    var $btn       = $(this);
+    var id         = $btn.data('id');
+    var $tr        = $btn.closest('tr');
+    var label      = $tr.find('.alfred-mem-label-input').val().trim();
+    var content    = $tr.find('.alfred-mem-content-input').val().trim();
+    var scope      = $tr.find('.alfred-mem-scope-input').val();
+    var expiresVal = $tr.find('.alfred-mem-expires-input').val().trim();
     if (!label || !content) return;
     $btn.prop('disabled', true);
     $.ajax({
         type: 'POST',
         url: 'plugins/alfred/core/ajax/alfred.ajax.php',
-        data: { action: 'updateMemory', id: id, label: label, content: content, scope: scope },
+        data: { action: 'updateMemory', id: id, label: label, content: content, scope: scope, expires_at: expiresVal },
         dataType: 'json',
         success: function (resp) {
             if (resp.state === 'ok') {
                 var m = _alfredMemories.filter(function (x) { return x.id == id; })[0];
-                if (m) { m.label = label; m.content = content; m.scope = scope; }
-                $tr.html(alfredMemoryRowView(m || { id: id, label: label, content: content, scope: scope, created_at: '' }));
+                var expiresAt = expiresVal ? expiresVal + ' 00:00:00' : null;
+                if (m) { m.label = label; m.content = content; m.scope = scope; m.expires_at = expiresAt; }
+                $tr.html(alfredMemoryRowView(m || { id: id, label: label, content: content, scope: scope, created_at: '', expires_at: expiresAt }));
             }
         },
         complete: function () { $btn.prop('disabled', false); }
@@ -1167,6 +1174,7 @@ function alfredMemoryRowNew() {
         + '<td><input type="text" class="form-control input-sm alfred-mem-label-input" placeholder="' + _alfredI18n.memory_label_ph + '" style="font-size:12px;font-family:monospace"></td>'
         + '<td><textarea class="form-control alfred-mem-content-input" rows="2" style="font-size:12px" placeholder="' + _alfredI18n.memory_content_ph + '"></textarea></td>'
         + '<td></td>'
+        + '<td><input type="date" class="form-control input-sm alfred-mem-expires-input" style="font-size:12px" title="{{Leave blank for no expiration}}"></td>'
         + '<td style="white-space:nowrap">'
         + '<button class="btn btn-xs btn-success alfred-memory-create-save" title="{{Save}}"><i class="fas fa-check"></i></button> '
         + '<button class="btn btn-xs btn-default alfred-memory-create-cancel" title="{{Cancel}}"><i class="fas fa-times"></i></button>'
@@ -1174,17 +1182,18 @@ function alfredMemoryRowNew() {
 }
 
 $(document).on('click', '.alfred-memory-create-save', function () {
-    var $btn    = $(this);
-    var $tr     = $btn.closest('tr');
-    var label   = $tr.find('.alfred-mem-label-input').val().trim();
-    var content = $tr.find('.alfred-mem-content-input').val().trim();
-    var scope   = $tr.find('.alfred-mem-scope-input').val();
+    var $btn       = $(this);
+    var $tr        = $btn.closest('tr');
+    var label      = $tr.find('.alfred-mem-label-input').val().trim();
+    var content    = $tr.find('.alfred-mem-content-input').val().trim();
+    var scope      = $tr.find('.alfred-mem-scope-input').val();
+    var expiresVal = $tr.find('.alfred-mem-expires-input').val().trim();
     if (!label || !content) return;
     $btn.prop('disabled', true);
     $.ajax({
         type: 'POST',
         url: 'plugins/alfred/core/ajax/alfred.ajax.php',
-        data: { action: 'createMemory', label: label, content: content, scope: scope },
+        data: { action: 'createMemory', label: label, content: content, scope: scope, expires_at: expiresVal },
         dataType: 'json',
         success: function (resp) {
             if (resp.state === 'ok') {


### PR DESCRIPTION
## Summary

- Adds `expires_at DATETIME DEFAULT NULL` column to `alfred_memory` via migration 004
- Memory entries can now expire automatically after a configurable number of days
- Expired entries are filtered at read time in `loadForUser()` and physically deleted daily via `cronDaily()`

## Changes

- **DB migration**: `alfredMigration` migration 004 adds `expires_at` column
- **`alfredMemory`**: `save()`, `updateByLabel()`, `adminUpdate()` accept optional expiration; `loadForUser()` filters expired rows; new `cronDaily()` deletes expired rows
- **`alfred`**: new `cronDaily()` method calls `alfredMemory::cronDaily()`
- **LLM tools**: `alfred_memory_save` adds `expires_in_days` field; `alfred_memory_update` adds `expires_in_days` (pass `0` to clear expiration)
- **System prompt**: memory headings show `*(expires YYYY-MM-DD)*` when set
- **Admin UI**: new "Expires" column in memory table with date picker in create/edit rows

Resolves #52