### PR TITLE
fix: trigger fallback on Ollama expired OAuth token error

### DIFF
--- a/core/class/alfredLLM.class.php
+++ b/core/class/alfredLLM.class.php
@@ -200,6 +200,7 @@ class alfredLLMChain extends alfredLLMAdapter
         $msg = $e->getMessage();
         if (strpos($msg, 'HTTP request failed') !== false) return true;
         if (preg_match('/\b(429|502|503|504)\b/', $msg)) return true;
+        if (stripos($msg, 'expired') !== false && stripos($msg, 'token') !== false) return true;
         return false;
     }
 }


### PR DESCRIPTION
## Summary

- Extends `isRetriable()` in `alfredLLM.class.php` to recognize expired/invalid token errors as retriable
- When Ollama returns an \"Invalid or Expired local Claude OAuth token\" error, the provider is now auto-disabled for 15 min and the fallback provider chain is triggered
- Uses a general `expired` + `token` keyword match to cover variations of this message

Resolves #56

## Test plan

- [ ] Configure a chain with Ollama as primary and a working provider as fallback
- [ ] Trigger an expired OAuth token error from Ollama
- [ ] Confirm the fallback provider handles the request instead of an exception being thrown