### PR TITLE
feat(journal): daily journal cron — summarize conversations into per-user memory

### DIFF
--- a/core/class/alfred.class.php
+++ b/core/class/alfred.class.php
@@ -41,12 +41,14 @@ class alfred extends eqLogic {
         }
         // Set default models
         $defaults = [
-            'mistral_model'   => 'mistral-large-latest',
-            'gemini_model'    => 'gemini-1.5-pro',
-            'ollama_base_url' => 'http://localhost:11434',
-            'ollama_model'    => 'mistral:latest',
-            'max_iterations'  => '10',
-            'system_prompt'   => 'You are Alfred, an AI assistant integrated into a Jeedom home automation system. You help the user control and monitor their smart home. Be concise and friendly.',
+            'mistral_model'            => 'mistral-large-latest',
+            'gemini_model'             => 'gemini-1.5-pro',
+            'ollama_base_url'          => 'http://localhost:11434',
+            'ollama_model'             => 'mistral:latest',
+            'max_iterations'           => '10',
+            'system_prompt'            => 'You are Alfred, an AI assistant integrated into a Jeedom home automation system. You help the user control and monitor their smart home. Be concise and friendly.',
+            'journal_daily_enabled'    => '0',
+            'journal_daily_expiry_days' => '10',
         ];
         foreach ($defaults as $key => $value) {
             if (config::byKey($key, __CLASS__) === '') {
@@ -99,6 +101,18 @@ class alfred extends eqLogic {
             alfredAsyncTask::processPending();
         } catch (Exception $e) {
             log::add('alfred_cron', 'error', 'cron: alfredAsyncTask failed — ' . $e->getMessage());
+        }
+    }
+
+    public static function cronDaily() {
+        require_once __DIR__ . '/alfredLLM.class.php';
+        require_once __DIR__ . '/alfredConversation.class.php';
+        require_once __DIR__ . '/alfredMemory.class.php';
+        require_once __DIR__ . '/alfredJournal.class.php';
+        try {
+            alfredJournal::cronDaily();
+        } catch (Exception $e) {
+            log::add('alfred_cron', 'error', 'cronDaily: alfredJournal failed — ' . $e->getMessage());
         }
     }
 

--- a/core/class/alfredJournal.class.php
+++ b/core/class/alfredJournal.class.php
@@ -1,0 +1,155 @@
+<?php
+
+class alfredJournal
+{
+    /**
+     * Jeedom daily cron hook.
+     * Summarize yesterday's conversations for each active user and store as a memory entry.
+     */
+    public static function cronDaily(): void
+    {
+        if (!(bool)config::byKey('journal_daily_enabled', 'alfred')) {
+            return;
+        }
+
+        $yesterday = date('Y-m-d', strtotime('-1 day'));
+        log::add('alfred_cron', 'info', "journal: generating daily entries for {$yesterday}");
+
+        $users = self::getActiveUsersForDate($yesterday);
+        if (empty($users)) {
+            log::add('alfred_cron', 'info', "journal: no active users for {$yesterday}");
+            return;
+        }
+
+        foreach ($users as $login) {
+            try {
+                self::generateJournalEntry($login, $yesterday);
+            } catch (Exception $e) {
+                log::add('alfred_cron', 'error', "journal: failed for user {$login} on {$yesterday}: " . $e->getMessage());
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+
+    private static function getActiveUsersForDate(string $date): array
+    {
+        $rows = DB::Prepare(
+            'SELECT DISTINCT c.user_login
+             FROM alfred_conversation c
+             JOIN alfred_message m ON m.session_id = c.session_id
+             WHERE c.user_login IS NOT NULL
+               AND m.role IN (\'user\', \'assistant\')
+               AND DATE(m.created_at) = :date',
+            [':date' => $date],
+            DB::FETCH_TYPE_ALL
+        ) ?: [];
+
+        return array_column($rows, 'user_login');
+    }
+
+    private static function generateJournalEntry(string $login, string $date): void
+    {
+        $transcript = self::buildTranscript($login, $date);
+        if ($transcript === '') {
+            log::add('alfred_cron', 'info', "journal: empty transcript for user {$login} on {$date}");
+            return;
+        }
+
+        $prompt = (string)config::byKey('journal_daily_prompt', 'alfred');
+        if ($prompt === '') {
+            $prompt = self::defaultPrompt();
+        }
+
+        $llm      = alfredLLM::make();
+        $messages = [['role' => 'user', 'content' => $prompt . "\n\n" . $transcript]];
+        $response = $llm->chat($messages, [], '');
+
+        $content = trim($response['text'] ?? '');
+        if ($content === '') {
+            log::add('alfred_cron', 'warning', "journal: LLM returned empty response for user {$login} on {$date}");
+            return;
+        }
+
+        $expiryDays = (int)config::byKey('journal_daily_expiry_days', 'alfred');
+        $expiresAt  = ($expiryDays > 0)
+            ? date('Y-m-d H:i:s', strtotime("+{$expiryDays} days"))
+            : null;
+
+        $label    = "journal-{$login}-{$date}";
+        $existing = alfredMemory::getByLabel($label);
+        if ($existing !== null) {
+            alfredMemory::adminUpdate($existing['id'], $label, $content, 'user:' . $login);
+        } else {
+            alfredMemory::save('user:' . $login, $label, $content, $expiresAt);
+        }
+
+        log::add('alfred_cron', 'info', "journal: entry saved for user {$login} ({$date})");
+    }
+
+    private static function buildTranscript(string $login, string $date): string
+    {
+        $sessions = DB::Prepare(
+            'SELECT DISTINCT c.session_id, c.title, c.created_at
+             FROM alfred_conversation c
+             JOIN alfred_message m ON m.session_id = c.session_id
+             WHERE c.user_login = :login
+               AND m.role IN (\'user\', \'assistant\')
+               AND DATE(m.created_at) = :date
+             ORDER BY c.created_at ASC',
+            [':login' => $login, ':date' => $date],
+            DB::FETCH_TYPE_ALL
+        ) ?: [];
+
+        if (empty($sessions)) {
+            return '';
+        }
+
+        $parts = [];
+        foreach ($sessions as $session) {
+            $messages = DB::Prepare(
+                'SELECT role, content, created_at FROM alfred_message
+                 WHERE session_id = :session_id
+                   AND role IN (\'user\', \'assistant\')
+                   AND DATE(created_at) = :date
+                 ORDER BY id ASC',
+                [':session_id' => $session['session_id'], ':date' => $date],
+                DB::FETCH_TYPE_ALL
+            ) ?: [];
+
+            if (empty($messages)) continue;
+
+            $title = ($session['title'] !== '' && $session['title'] !== null)
+                ? $session['title']
+                : substr($session['session_id'], 0, 8);
+            $time  = substr($session['created_at'], 0, 16);
+
+            $block = "=== [{$time}] {$title} ===\n";
+            foreach ($messages as $msg) {
+                $ts      = substr($msg['created_at'], 11, 5);
+                $role    = $msg['role'] === 'user' ? 'User' : 'Alfred';
+                $content = $msg['content'];
+                // Content may be JSON-encoded — decode for readability
+                $decoded = json_decode($content, true);
+                if (is_string($decoded)) {
+                    $content = $decoded;
+                } elseif (is_array($decoded)) {
+                    $content = json_encode($decoded, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+                }
+                $block .= "[{$ts}] {$role}: {$content}\n";
+            }
+            $parts[] = $block;
+        }
+
+        return implode("\n\n", $parts);
+    }
+
+    private static function defaultPrompt(): string
+    {
+        return 'Below is a transcript of conversations between a user and Alfred (an AI home assistant) from yesterday.'
+            . ' Write a concise memory note (3-7 sentences) summarizing:'
+            . ' the main topics discussed, any decisions or instructions given,'
+            . ' preferences or habits expressed, and anything useful for future context.'
+            . ' Write in third person about the user. No preamble or headings.';
+    }
+}

--- a/core/class/alfredMemory.class.php
+++ b/core/class/alfredMemory.class.php
@@ -5,13 +5,14 @@ class alfredMemory
     /**
      * Save a new memory. $scope must be "global" or "user:{login}".
      * $label is a short text identifier (e.g. "vacation-july-2026").
+     * $expiresAt is an optional MySQL DATETIME string; NULL means never expires.
      * Returns the new memory ID.
      */
-    public static function save(string $scope, string $label, string $content): int
+    public static function save(string $scope, string $label, string $content, ?string $expiresAt = null): int
     {
         DB::Prepare(
-            'INSERT INTO alfred_memory (scope, label, content) VALUES (:scope, :label, :content)',
-            [':scope' => $scope, ':label' => $label, ':content' => $content],
+            'INSERT INTO alfred_memory (scope, label, content, expires_at) VALUES (:scope, :label, :content, :expires_at)',
+            [':scope' => $scope, ':label' => $label, ':content' => $content, ':expires_at' => $expiresAt],
             DB::FETCH_TYPE_ROW
         );
         return (int)DB::getLastInsertId();
@@ -89,13 +90,15 @@ class alfredMemory
     }
 
     /**
-     * Load all memories visible to a user: global + user:{login}.
+     * Load all non-expired memories visible to a user: global + user:{login}.
      */
     public static function loadForUser(string $login): array
     {
         return DB::Prepare(
             'SELECT id, scope, label, content, created_at FROM alfred_memory'
-            . ' WHERE scope IN (:g, :u) ORDER BY created_at ASC',
+            . ' WHERE scope IN (:g, :u)'
+            . ' AND (expires_at IS NULL OR expires_at > NOW())'
+            . ' ORDER BY created_at ASC',
             [':g' => 'global', ':u' => 'user:' . $login],
             DB::FETCH_TYPE_ALL
         ) ?: [];
@@ -107,7 +110,7 @@ class alfredMemory
     public static function loadAll(): array
     {
         return DB::Prepare(
-            'SELECT id, scope, label, content, created_at, updated_at FROM alfred_memory ORDER BY scope, created_at ASC',
+            'SELECT id, scope, label, content, created_at, updated_at, expires_at FROM alfred_memory ORDER BY scope, created_at ASC',
             [],
             DB::FETCH_TYPE_ALL
         ) ?: [];

--- a/core/class/alfredMigration.class.php
+++ b/core/class/alfredMigration.class.php
@@ -6,6 +6,7 @@ class alfredMigration
         1 => 'migration_001_baseline',
         2 => 'migration_002_async_tasks',
         3 => 'migration_003_push_notifications',
+        4 => 'migration_004_memory_expiry',
     ];
 
     private static function downDir(): string
@@ -387,5 +388,31 @@ class alfredMigration
             'DROP TABLE IF EXISTS `alfred_push_notification`',
             'DROP TABLE IF EXISTS `alfred_push_subscription`',
         ]);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Migration 4 — Add expires_at column to alfred_memory (for journal expiry)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private static function migration_004_memory_expiry(): void
+    {
+        $row = DB::Prepare(
+            "SELECT COUNT(*) as cnt FROM information_schema.columns
+             WHERE table_schema = DATABASE() AND table_name = 'alfred_memory' AND column_name = 'expires_at'",
+            [],
+            DB::FETCH_TYPE_ROW
+        );
+        if (!isset($row['cnt']) || (int)$row['cnt'] === 0) {
+            DB::Prepare(
+                'ALTER TABLE `alfred_memory` ADD COLUMN `expires_at` DATETIME DEFAULT NULL',
+                [],
+                DB::FETCH_TYPE_ROW
+            );
+        }
+    }
+
+    private static function migration_004_memory_expiry_down(): string
+    {
+        return 'ALTER TABLE `alfred_memory` DROP COLUMN `expires_at`';
     }
 }

--- a/plugin_info/configuration.php
+++ b/plugin_info/configuration.php
@@ -235,6 +235,40 @@ $_mcpServersJson = is_array($_mcpRaw) ? (json_encode($_mcpRaw) ?: '[]') : ($_mcp
         </div>
 
         <!-- ================================================================ -->
+        <!-- Daily Journal -->
+        <!-- ================================================================ -->
+        <legend><i class="fas fa-book"></i> {{Daily journal}}</legend>
+
+        <div class="form-group">
+            <label class="col-sm-4 control-label">{{Enable daily journal}}</label>
+            <div class="col-sm-8" style="padding-top:7px">
+                <input type="checkbox" class="configKey" data-l1key="journal_daily_enabled" />
+                <span class="help-block" style="display:inline;margin-left:8px">
+                    {{Each night, summarize the day's conversations into a per-user memory entry.}}
+                </span>
+            </div>
+        </div>
+
+        <div class="form-group">
+            <label class="col-sm-4 control-label">{{Journal prompt}}</label>
+            <div class="col-sm-6">
+                <textarea class="configKey form-control" data-l1key="journal_daily_prompt" rows="5"
+                          style="font-family: monospace; font-size: 12px;"
+                          placeholder="{{Leave empty to use the default prompt.}}"></textarea>
+            </div>
+            <span class="help-block col-sm-2">{{LLM instruction for generating the journal entry. Leave empty for the default.}}</span>
+        </div>
+
+        <div class="form-group">
+            <label class="col-sm-4 control-label">{{Journal expiry (days)}}</label>
+            <div class="col-sm-2">
+                <input type="number" class="configKey form-control" data-l1key="journal_daily_expiry_days"
+                       min="0" max="365" placeholder="10" />
+            </div>
+            <span class="help-block col-sm-6">{{Days before the journal memory entry expires. 0 = never.}}</span>
+        </div>
+
+        <!-- ================================================================ -->
         <!-- Phones -->
         <!-- ================================================================ -->
         <legend><i class="fas fa-mobile-alt"></i> {{Phones}}</legend>


### PR DESCRIPTION
## Summary

- New `alfredJournal` class with `cronDaily()` hook (called by Jeedom's daily scheduler) that queries yesterday's `user`/`assistant` messages, builds a per-session transcript for each active user, calls the configured LLM (no tools), and saves the result as a `user:{login}`-scoped memory entry labeled `journal-{login}-YYYY-MM-DD`.
- Three configurable settings added to the config panel:
  - `journal_daily_enabled` (checkbox, default off) — master toggle
  - `journal_daily_prompt` (textarea) — custom LLM instruction; empty = use built-in default
  - `journal_daily_expiry_days` (integer, default 10) — days before entry expires; 0 = never
- Migration 4 adds `expires_at DATETIME NULL` to `alfred_memory`; `alfredMemory::save()` accepts it as an optional parameter; `loadForUser()` filters expired entries automatically.

## Test plan

- [ ] Enable the journal in plugin config and verify `alfred::cronDaily()` is invoked by Jeedom once per day
- [ ] Manually call `alfredJournal::cronDaily()` with test conversations from yesterday; confirm memory entry saved with label `journal-{login}-YYYY-MM-DD` and correct scope
- [ ] Set `journal_daily_expiry_days = 3`; verify `expires_at = NOW() + 3 days` on the memory row
- [ ] Set `journal_daily_expiry_days = 0`; verify `expires_at IS NULL`
- [ ] Disable journal (`journal_daily_enabled = false`); verify `cronDaily()` returns immediately without LLM calls
- [ ] Verify `loadForUser()` excludes memories past their `expires_at`
- [ ] Confirm migration 4 runs cleanly on fresh install and upgrade from schema v3

Resolves #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)