### PR TITLE
feat: group conversations by date in sidebar menu

### DIFF
--- a/chat/index.php
+++ b/chat/index.php
@@ -112,6 +112,15 @@ if (isConnect()) {
             font-style: italic;
         }
 
+        .alfred-date-group-label {
+            padding: 8px 12px 3px;
+            font-size: 11px;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            color: #aaa;
+            font-weight: 600;
+        }
+
         .alfred-session-item {
             display: flex;
             align-items: center;
@@ -1167,13 +1176,32 @@ $(function () {
         });
     }
 
+    function getDateGroupLabel(dateStr) {
+        if (!dateStr) return '';
+        var today = new Date();
+        today.setHours(0, 0, 0, 0);
+        var yesterday = new Date(today);
+        yesterday.setDate(yesterday.getDate() - 1);
+        var d = new Date(dateStr.replace(' ', 'T'));
+        d.setHours(0, 0, 0, 0);
+        if (d.getTime() === today.getTime()) return 'Aujourd\'hui';
+        if (d.getTime() === yesterday.getTime()) return 'Hier';
+        return d.toLocaleDateString(navigator.language, { day: 'numeric', month: 'long' });
+    }
+
     function renderSessionList(sessions) {
         var $container = $('#alfred-conversations').empty();
         if (!sessions || sessions.length === 0) {
             $container.append('<div class="alfred-sessions-empty">No conversations yet</div>');
             return;
         }
+        var currentGroup = null;
         sessions.forEach(function (s) {
+            var label = getDateGroupLabel(s.updated_at);
+            if (label !== currentGroup) {
+                currentGroup = label;
+                $container.append($('<div class="alfred-date-group-label">').text(label));
+            }
             var $title  = $('<span class="alfred-session-title">').text(s.title || s.session_id.substr(0, 8) + '…');
             var $rename = $('<button type="button" class="alfred-session-rename" title="Rename">')
                 .html('<i class="fas fa-pencil-alt"></i>');

--- a/desktop/css/alfred.css
+++ b/desktop/css/alfred.css
@@ -87,6 +87,15 @@
     font-style: italic;
 }
 
+.alfred-date-group-label {
+    padding: 8px 12px 3px;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: #aaa;
+    font-weight: 600;
+}
+
 .alfred-session-item {
     display: flex;
     align-items: center;

--- a/desktop/js/alfred.js
+++ b/desktop/js/alfred.js
@@ -80,6 +80,19 @@ $(function () {
         });
     }
 
+    function getDateGroupLabel(dateStr) {
+        if (!dateStr) return '';
+        var today = new Date();
+        today.setHours(0, 0, 0, 0);
+        var yesterday = new Date(today);
+        yesterday.setDate(yesterday.getDate() - 1);
+        var d = new Date(dateStr.replace(' ', 'T'));
+        d.setHours(0, 0, 0, 0);
+        if (d.getTime() === today.getTime()) return alfred_config.i18n.today;
+        if (d.getTime() === yesterday.getTime()) return alfred_config.i18n.yesterday;
+        return d.toLocaleDateString(navigator.language, { day: 'numeric', month: 'long' });
+    }
+
     function renderSessionList(sessions) {
         var $container = $('#alfred-conversations').empty();
         if (!sessions || sessions.length === 0) {
@@ -87,7 +100,13 @@ $(function () {
             return;
         }
 
+        var currentGroup = null;
         sessions.forEach(function (s) {
+            var label = getDateGroupLabel(s.updated_at);
+            if (label !== currentGroup) {
+                currentGroup = label;
+                $container.append($('<div class="alfred-date-group-label">').text(label));
+            }
             var $title = $('<span class="alfred-session-title">').text(s.title || s.session_id.substr(0, 8) + '…');
             var $rename = $('<button type="button" class="alfred-session-rename" title="{{Rename}}">')
                 .html('<i class="fas fa-pencil-alt"></i>');

--- a/desktop/php/alfred.php
+++ b/desktop/php/alfred.php
@@ -91,8 +91,10 @@ var alfred_config = {
     userHash: "<?php echo htmlspecialchars($_userHash, ENT_QUOTES); ?>",
     isAdmin: <?php echo ($_SESSION['user']->getProfils() === 'admin') ? 'true' : 'false'; ?>,
     i18n: {
-        hello: "{{Hello, I'm Alfred.}}",
-        ask:   "{{Ask me anything about your home automation system.}}"
+        hello:     "{{Hello, I'm Alfred.}}",
+        ask:       "{{Ask me anything about your home automation system.}}",
+        today:     "{{Today}}",
+        yesterday: "{{Yesterday}}"
     }
 };
 // Persist auth info so the standalone PWA can work without a PHP session


### PR DESCRIPTION
## Summary

- Groups conversation entries in the sidebar under date section headers
- Shows **Today** / **Yesterday** for recent dates (translated via the existing `fr_FR.json` entries)
- Shows a locale-formatted date (e.g. "2 août") for older conversations, using `navigator.language` so it adapts to the user's browser locale

## Changes

- **`desktop/js/alfred.js`** — `getDateGroupLabel()` helper computes the label for a given `updated_at` timestamp; `renderSessionList()` now inserts an `.alfred-date-group-label` divider whenever the group label changes (sessions are already ordered by `updated_at DESC`, so groups always appear in descending chronological order)
- **`desktop/php/alfred.php`** — adds `today` and `yesterday` keys to `alfred_config.i18n` so the Jeedom-translated strings are safely surfaced to JavaScript (avoids the apostrophe-in-single-quote pitfall)
- **`desktop/css/alfred.css`** — `.alfred-date-group-label` styled to match the existing sidebar label conventions (11px, uppercase, muted)

Resolves #60