### PR TITLE
feat(journal): inject user and global memories into journal generation context

### DIFF
--- a/core/ajax/alfred.ajax.php
+++ b/core/ajax/alfred.ajax.php
@@ -218,7 +218,8 @@ try {
         require_once __DIR__ . '/../class/alfredJournal.class.php';
         require_once __DIR__ . '/../class/alfredLLM.class.php';
         require_once __DIR__ . '/../class/alfredMemory.class.php';
-        ajax::success(alfredJournal::runForDate($date));
+        $promptOverride = trim(init('prompt'));
+        ajax::success(alfredJournal::runForDate($date, $promptOverride));
     }
 
     if ($action === 'regenVapid') {

--- a/core/class/alfredJournal.class.php
+++ b/core/class/alfredJournal.class.php
@@ -75,9 +75,19 @@ class alfredJournal
             return ['login' => $login, 'date' => $date, 'prompt' => $prompt, 'transcript' => '', 'result' => null, 'skipped' => true];
         }
 
+        $memories     = alfredMemory::loadForUser($login);
+        $systemPrompt = '';
+        if (!empty($memories)) {
+            $systemPrompt = "## Persistent memory\n";
+            foreach ($memories as $m) {
+                $heading       = $m['label'] !== '' ? $m['label'] : (($m['scope'] === 'global' ? 'global' : 'personal') . '-' . $m['id']);
+                $systemPrompt .= "\n### {$heading}\n{$m['content']}\n";
+            }
+        }
+
         $llm      = alfredLLM::make();
         $messages = [['role' => 'user', 'content' => $prompt . "\n\n" . $transcript]];
-        $response = $llm->chat($messages, [], '');
+        $response = $llm->chat($messages, [], $systemPrompt);
 
         $content = trim($response['text'] ?? '');
         if ($content === '') {

--- a/core/class/alfredJournal.class.php
+++ b/core/class/alfredJournal.class.php
@@ -68,6 +68,7 @@ class alfredJournal
         if ($prompt === '') {
             $prompt = self::defaultPrompt();
         }
+        $prompt = str_replace(['{date}', '{username}'], [$date, $login], $prompt);
 
         $transcript = self::buildTranscript($login, $date);
         if ($transcript === '') {
@@ -171,10 +172,12 @@ class alfredJournal
 
     private static function defaultPrompt(): string
     {
-        return 'Below is a transcript of conversations between a user and Alfred (an AI home assistant) from yesterday.'
-            . ' Write a concise memory note (3-7 sentences) summarizing:'
-            . ' the main topics discussed, any decisions or instructions given,'
-            . ' preferences or habits expressed, and anything useful for future context.'
-            . ' Write in third person about the user. No preamble or headings.';
+        return "Tu es Alfred, le majordome de la maison.\n"
+            . "Voici la transcription de tes échanges du {date} avec {username}.\n"
+            . "Ta mémoire persistante est disponible dans le contexte système.\n\n"
+            . "Extrait uniquement les faits NOUVEAUX par rapport à ta mémoire existante,"
+            . " en te concentrant sur les réponses de l'utilisateur (pas tes propres messages).\n"
+            . "Format : une ligne par fait, pas de phrase complète.\n"
+            . "Maximum 300 caractères. Si rien de nouveau : réponds uniquement \"rien\".";
     }
 }

--- a/core/class/alfredJournal.class.php
+++ b/core/class/alfredJournal.class.php
@@ -52,19 +52,19 @@ class alfredJournal
      * Run journal generation for all active users on $date.
      * Returns per-user results (prompt, transcript, LLM output).
      */
-    public static function runForDate(string $date): array
+    public static function runForDate(string $date, string $promptOverride = ''): array
     {
         $users   = self::getActiveUsersForDate($date);
         $results = [];
         foreach ($users as $login) {
-            $results[] = self::generateJournalEntry($login, $date);
+            $results[] = self::generateJournalEntry($login, $date, $promptOverride);
         }
         return $results;
     }
 
-    public static function generateJournalEntry(string $login, string $date): array
+    public static function generateJournalEntry(string $login, string $date, string $promptOverride = ''): array
     {
-        $prompt = (string)config::byKey('journal_daily_prompt', 'alfred');
+        $prompt = $promptOverride !== '' ? $promptOverride : (string)config::byKey('journal_daily_prompt', 'alfred');
         if ($prompt === '') {
             $prompt = self::defaultPrompt();
         }

--- a/plugin_info/configuration.php
+++ b/plugin_info/configuration.php
@@ -1247,7 +1247,7 @@ $('#bt_alfred_run_journal').on('click', function () {
     $.ajax({
         type:     'POST',
         url:      'plugins/alfred/core/ajax/alfred.ajax.php',
-        data:     { action: 'runJournal', date: date },
+        data:     { action: 'runJournal', date: date, prompt: $('[data-l1key="journal_daily_prompt"]').val() },
         dataType: 'json',
         success:  function (data) {
             if (data.state !== 'ok') {


### PR DESCRIPTION
## Summary
- Loads all non-expired memories for the user (global + user-scoped) before calling the LLM
- Passes them as a system prompt in the same `## Persistent memory / ### {label}` format used by `alfredAgent`
- The journal summary now has full context about the user's preferences and known facts

## Why
Without memory context, the LLM generates a generic summary that ignores everything Alfred already knows about the user. With it, the journal can reference existing context and produce more useful, personalized entries.

Closes #64